### PR TITLE
Check for existing record when custom controller is given

### DIFF
--- a/packages/did-datastore/src/index.ts
+++ b/packages/did-datastore/src/index.ts
@@ -446,12 +446,12 @@ export class DIDDataStore<
   async _setRecordOnly(
     definitionID: string,
     content: Record<string, any>,
-    { pin }: CreateOptions = {}
+    options: CreateOptions = {}
   ): Promise<[boolean, StreamID]> {
-    const existing = await this.getRecordID(definitionID, this.id)
+    const existing = await this.getRecordID(definitionID, options.controller ?? this.id)
     if (existing == null) {
       const definition = await this.getDefinition(definitionID)
-      const ref = await this._createRecord(definition, content, { pin })
+      const ref = await this._createRecord(definition, content, options)
       return [true, ref]
     } else {
       const doc = await this.#loader.load(existing)

--- a/packages/did-datastore/test/lib.test.ts
+++ b/packages/did-datastore/test/lib.test.ts
@@ -637,7 +637,7 @@ describe('DIDDataStore', () => {
 
         const ds = new DIDDataStore({ ceramic: { did: { id: 'did' } }, model } as any)
         const getRecordID = jest.fn((_, did) => {
-          return did == "did" ? Promise.resolve('streamId') : Promise.resolve(null)
+          return did == 'did' ? Promise.resolve('streamId') : Promise.resolve(null)
         })
         ds.getRecordID = getRecordID
 
@@ -648,13 +648,15 @@ describe('DIDDataStore', () => {
         ds._createRecord = createRecord as any
 
         const content = { test: true }
-        await expect(ds._setRecordOnly('defId', content, { controller: "did:foo:123", pin: true })).resolves.toEqual([
-          true,
-          'streamId',
-        ])
+        await expect(
+          ds._setRecordOnly('defId', content, { controller: 'did:foo:123', pin: true })
+        ).resolves.toEqual([true, 'streamId'])
         expect(getRecordID).toBeCalledWith('defId', 'did:foo:123')
         expect(getDefinition).toBeCalledWith('defId')
-        expect(createRecord).toBeCalledWith(definition, content, { pin: true })
+        expect(createRecord).toBeCalledWith(definition, content, {
+          controller: 'did:foo:123',
+          pin: true,
+        })
       })
     })
 


### PR DESCRIPTION
# Check for existing record when custom controller is given - https://github.com/ceramicstudio/js-glaze/issues/93

## Description

Fixes https://github.com/ceramicstudio/js-glaze/issues/93

@PaulLeCam 

## How Has This Been Tested?

See new test case for `_setRecordOnly`

## Definition of Done

Before submitting this PR, please make sure:

- [x] The work addresses the description and outcomes in the issue
- [x] I have added relevant tests for new or updated functionality
- [x] My code follows conventions, is well commented, and easy to understand
- [x] My code builds and tests pass without any errors or warnings
- [x] I have tagged the relevant reviewers
- [x] I have updated the READMEs of affected packages
- [x] I have made corresponding changes to the documentation
- [x] The changes have been communicated to interested parties

## References:

None.