### PR TITLE
fix(tile-loader): match tile document deterministic return type

### DIFF
--- a/packages/tile-loader/src/index.ts
+++ b/packages/tile-loader/src/index.ts
@@ -154,10 +154,10 @@ export class TileLoader extends DataLoader<TileKey, TileDocument> {
   async deterministic<T extends Record<string, any> = Record<string, any>>(
     metadata: TileMetadataArgs,
     options?: CreateOpts
-  ): Promise<TileDocument<T | null | undefined>> {
+  ): Promise<TileDocument<T>> {
     const query = await getDeterministicQuery(metadata)
     try {
-      return (await super.load(query)) as TileDocument<T | null | undefined>
+      return (await super.load(query)) as TileDocument<T>
     } catch (err) {
       const stream = await TileDocument.createFromGenesis<T>(
         this.#ceramic,


### PR DESCRIPTION
Changed to match tile document deterministic return type, not sure if i'm missing any reason for undefined/null types 
