### PR TITLE
Update loader cache after DataStore record updates

### DIFF
--- a/packages/did-datastore/package.json
+++ b/packages/did-datastore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@glazed/did-datastore",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "author": "3Box Labs",
   "license": "(Apache-2.0 OR MIT)",
   "homepage": "https://github.com/ceramicstudio/js-glaze#readme",

--- a/packages/did-datastore/src/index.ts
+++ b/packages/did-datastore/src/index.ts
@@ -8,6 +8,7 @@
 
 import type { CeramicApi } from '@ceramicnetwork/common'
 import { StreamID } from '@ceramicnetwork/streamid'
+import type { TileDocument } from '@ceramicnetwork/stream-tile'
 import { CIP11_DEFINITION_SCHEMA_URL, CIP11_INDEX_SCHEMA_URL } from '@glazed/constants'
 import { DataModel } from '@glazed/datamodel'
 import type { Definition, IdentityIndex } from '@glazed/did-datastore-model'
@@ -362,6 +363,7 @@ export class DIDDataStore<
     if (doc.content == null || doc.metadata.schema == null) {
       // Doc just got created, set to empty object with schema
       await doc.update({}, { schema: CIP11_INDEX_SCHEMA_URL }, { pin: this.#autopin })
+      this.#loader.cache(doc as TileDocument<Record<string, any>>)
     } else if (doc.metadata.schema !== CIP11_INDEX_SCHEMA_URL) {
       throw new Error('Invalid document: schema is not IdentityIndex')
     }
@@ -456,6 +458,7 @@ export class DIDDataStore<
     } else {
       const doc = await this.#loader.load(existing)
       await doc.update(content)
+      this.#loader.cache(doc)
       return [false, doc.id]
     }
   }
@@ -473,6 +476,7 @@ export class DIDDataStore<
     })
     // Then be updated with content and schema
     await doc.update(content, { schema: definition.schema }, { pin: pin ?? this.#autopin })
+    this.#loader.cache(doc as TileDocument<Record<string, any>>)
     return doc.id
   }
 

--- a/packages/did-datastore/test/integration.test.ts
+++ b/packages/did-datastore/test/integration.test.ts
@@ -73,7 +73,7 @@ describe('integration', () => {
     await store.set('profile2', { name: 'Bob' })
     const cachedRecord = await cache.get(recordID.toString())
     // Cached record should have been updated
-    expect(cachedRecord.content).toEqual({ name: 'Bob' })
+    expect(cachedRecord?.content).toEqual({ name: 'Bob' })
     // Check get() method has same content as cache
     await expect(store.get('profile2')).resolves.toEqual({ name: 'Bob' })
   })

--- a/packages/did-datastore/test/integration.test.ts
+++ b/packages/did-datastore/test/integration.test.ts
@@ -4,6 +4,7 @@
 /* eslint-disable @typescript-eslint/no-unsafe-argument */
 
 import type { CeramicApi } from '@ceramicnetwork/common'
+import type { TileDocument } from '@ceramicnetwork/stream-tile'
 import { ModelManager } from '@glazed/devtools'
 import type { ModelTypeAliases, PublishedModel } from '@glazed/types'
 
@@ -60,7 +61,7 @@ describe('integration', () => {
   })
 
   test('create, update and load record from cache', async () => {
-    const cache = new Map()
+    const cache = new Map<string, Promise<TileDocument>>()
     const store = new DIDDataStore<ModelTypes>({ cache, ceramic, model })
 
     // Sanity check to ensure record doesn't already exist

--- a/packages/did-datastore/test/integration.test.ts
+++ b/packages/did-datastore/test/integration.test.ts
@@ -5,7 +5,7 @@
 
 import type { CeramicApi } from '@ceramicnetwork/common'
 import { ModelManager } from '@glazed/devtools'
-import type { ModelTypeAliases } from '@glazed/types'
+import type { ModelTypeAliases, PublishedModel } from '@glazed/types'
 
 // Note: we're using the dist lib here to make sure it behaves as expected
 import { DIDDataStore } from '..'
@@ -14,12 +14,16 @@ declare global {
   const ceramic: CeramicApi
 }
 
-type ModelTypes = ModelTypeAliases<{ Profile: { name?: string } }, { profile: 'Profile' }>
+type ModelTypes = ModelTypeAliases<
+  { Profile: { name?: string } },
+  { profile1: 'Profile'; profile2: 'Profile' }
+>
 
 describe('integration', () => {
   jest.setTimeout(20000)
 
-  test('get and set a definition', async () => {
+  let model: PublishedModel<ModelTypes>
+  beforeAll(async () => {
     const manager = new ModelManager(ceramic)
     const schemaID = await manager.createSchema('Profile', {
       $schema: 'http://json-schema.org/draft-07/schema#',
@@ -32,20 +36,44 @@ describe('integration', () => {
         },
       },
     } as any)
-    await manager.createDefinition('profile', {
+    const definition = {
       name: 'Profile',
       description: 'test profile',
       schema: manager.getSchemaURL(schemaID) as string,
-    })
-    const model = await manager.toPublished()
+    }
+    await Promise.all([
+      manager.createDefinition('profile1', definition),
+      manager.createDefinition('profile2', definition),
+    ])
+    model = await manager.toPublished()
+  })
 
+  test('get and set a record', async () => {
     const writer = new DIDDataStore<ModelTypes>({ ceramic, model })
     // We can use the alias provided in the definitions to identify a resource
-    await writer.set('profile', { name: 'Alice' })
+    await writer.set('profile1', { name: 'Alice' })
 
     const reader = new DIDDataStore<ModelTypes>({ ceramic, model })
     // The definition StreamID can also be used to identify a known resource
-    const doc = await reader.get('profile', writer.id)
+    const doc = await reader.get('profile1', writer.id)
     expect(doc).toEqual({ name: 'Alice' })
+  })
+
+  test('create, update and load record from cache', async () => {
+    const cache = new Map()
+    const store = new DIDDataStore<ModelTypes>({ cache, ceramic, model })
+
+    // Sanity check to ensure record doesn't already exist
+    await expect(store.has('profile2')).resolves.toBe(false)
+    const recordID = await store.set('profile2', { name: 'Alice' })
+    // Check record has been added to the cache
+    expect(cache.has(recordID.toString())).toBe(true)
+
+    await store.set('profile2', { name: 'Bob' })
+    const cachedRecord = await cache.get(recordID.toString())
+    // Cached record should have been updated
+    expect(cachedRecord.content).toEqual({ name: 'Bob' })
+    // Check get() method has same content as cache
+    await expect(store.get('profile2')).resolves.toEqual({ name: 'Bob' })
   })
 })


### PR DESCRIPTION
## Description

Following [Zach's comment](https://github.com/ceramicstudio/3id-connect/pull/218#discussion_r783321873) I checked the behavior of the DID DataStore and realized the current logic doesn't update the loader cache after stream updates, which might explain the issue he's having. Even if unrelated, I think the DataStore should take care of it explicitly to avoid unexpected apps/libs behaviors.

## How Has This Been Tested?

- Added unit tests to relevant methods to check the cache update method is called on the loader
- Added integration test with direct checks on the cache
