### PR TITLE
Backport fix to bypass TileLoader cache before updates

### DIFF
--- a/docs/classes/tile_loader.TileLoader.md
+++ b/docs/classes/tile_loader.TileLoader.md
@@ -122,3 +122,30 @@ Load a TileDocument from the cache (if enabled) or remotely.
 #### Overrides
 
 DataLoader.load
+
+___
+
+### update
+
+▸ **update**<`T`\>(`streamID`, `content?`, `metadata?`, `options?`): `Promise`<`TileDocument`<`undefined` \| ``null`` \| `T`\>\>
+
+Update a TileDocument after loading the stream remotely, bypassing the cache.
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `T` | extends `Record`<`string`, `any`\> = `Record`<`string`, `any`\> |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `streamID` | `string` \| `StreamID` |
+| `content?` | `T` |
+| `metadata?` | `TileMetadataArgs` |
+| `options?` | `UpdateOpts` |
+
+#### Returns
+
+`Promise`<`TileDocument`<`undefined` \| ``null`` \| `T`\>\>

--- a/packages/did-datastore/package.json
+++ b/packages/did-datastore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@glazed/did-datastore",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "author": "3Box Labs",
   "license": "(Apache-2.0 OR MIT)",
   "homepage": "https://github.com/ceramicstudio/js-glaze#readme",
@@ -40,7 +40,7 @@
     "@ceramicnetwork/streamid": "^1.3.3",
     "@glazed/constants": "^0.1.1",
     "@glazed/datamodel": "^0.2.0",
-    "@glazed/tile-loader": "^0.1.0"
+    "@glazed/tile-loader": "^0.1.3"
   },
   "devDependencies": {
     "@ceramicnetwork/blockchain-utils-linking": "^1.4.0",

--- a/packages/did-datastore/src/index.ts
+++ b/packages/did-datastore/src/index.ts
@@ -8,16 +8,13 @@
 
 import type { CeramicApi } from '@ceramicnetwork/common'
 import { StreamID } from '@ceramicnetwork/streamid'
-import type { TileDocument } from '@ceramicnetwork/stream-tile'
 import { CIP11_DEFINITION_SCHEMA_URL, CIP11_INDEX_SCHEMA_URL } from '@glazed/constants'
 import { DataModel } from '@glazed/datamodel'
 import type { Definition, IdentityIndex } from '@glazed/did-datastore-model'
-import { TileLoader, getDeterministicQuery } from '@glazed/tile-loader'
-import type { TileCache } from '@glazed/tile-loader'
+import { type TileCache, TileLoader, getDeterministicQuery } from '@glazed/tile-loader'
 import type { ModelTypeAliases, ModelTypesToAliases } from '@glazed/types'
 
-import { TileProxy } from './proxy'
-import type { TileDoc } from './proxy'
+import { TileProxy, type TileDoc } from './proxy'
 import { getIDXMetadata } from './utils'
 
 export { assertDIDstring, isDIDstring } from './utils'
@@ -363,7 +360,6 @@ export class DIDDataStore<
     if (doc.content == null || doc.metadata.schema == null) {
       // Doc just got created, set to empty object with schema
       await doc.update({}, { schema: CIP11_INDEX_SCHEMA_URL }, { pin: this.#autopin })
-      this.#loader.cache(doc as TileDocument<Record<string, any>>)
     } else if (doc.metadata.schema !== CIP11_INDEX_SCHEMA_URL) {
       throw new Error('Invalid document: schema is not IdentityIndex')
     }
@@ -456,9 +452,7 @@ export class DIDDataStore<
       const ref = await this._createRecord(definition, content, options)
       return [true, ref]
     } else {
-      const doc = await this.#loader.load(existing)
-      await doc.update(content)
-      this.#loader.cache(doc)
+      const doc = await this.#loader.update(existing, content)
       return [false, doc.id]
     }
   }
@@ -476,7 +470,6 @@ export class DIDDataStore<
     })
     // Then be updated with content and schema
     await doc.update(content, { schema: definition.schema }, { pin: pin ?? this.#autopin })
-    this.#loader.cache(doc as TileDocument<Record<string, any>>)
     return doc.id
   }
 

--- a/packages/did-datastore/test/lib.test.ts
+++ b/packages/did-datastore/test/lib.test.ts
@@ -449,8 +449,6 @@ describe('DIDDataStore', () => {
 
     describe('_getOwnIDXDoc()', () => {
       test('creates and sets schema in update', async () => {
-        const cache = jest.fn(() => true)
-        Loader.mockImplementationOnce(() => ({ cache } as unknown as TileLoader))
         const id = 'did:test:123'
         const metadata = { controllers: [id], family: 'IDX' }
         const update = jest.fn()
@@ -462,7 +460,6 @@ describe('DIDDataStore', () => {
         await expect(ds._getOwnIDXDoc(id)).resolves.toBe(doc)
         expect(createDoc).toHaveBeenCalledWith(id)
         expect(update).toHaveBeenCalledWith({}, { schema: CIP11_INDEX_SCHEMA_URL }, { pin: true })
-        expect(cache).toBeCalledWith(doc)
       })
 
       test('returns the doc if valid', async () => {
@@ -599,11 +596,9 @@ describe('DIDDataStore', () => {
 
     describe('_setRecordOnly()', () => {
       test('existing definition ID', async () => {
-        const update = jest.fn()
-        const record = { update, id: 'streamId' }
-        const load = jest.fn(() => Promise.resolve(record))
-        const cache = jest.fn(() => true)
-        Loader.mockImplementationOnce(() => ({ load, cache } as unknown as TileLoader))
+        const record = { update: jest.fn(), id: 'streamId' }
+        const update = jest.fn(() => Promise.resolve(record))
+        Loader.mockImplementationOnce(() => ({ update } as unknown as TileLoader))
 
         const ds = new DIDDataStore({ ceramic: { did: { id: 'did:foo:123' } }, model } as any)
         const getRecordID = jest.fn(() => Promise.resolve('streamId'))
@@ -614,9 +609,7 @@ describe('DIDDataStore', () => {
           ds._setRecordOnly('defId', content, { controller: 'did:foo:456' })
         ).resolves.toEqual([false, 'streamId'])
         expect(getRecordID).toBeCalledWith('defId', 'did:foo:456')
-        expect(load).toBeCalledWith('streamId')
-        expect(update).toBeCalledWith(content)
-        expect(cache).toBeCalledWith(record)
+        expect(update).toBeCalledWith('streamId', content)
       })
 
       test('adding definition ID', async () => {
@@ -672,12 +665,11 @@ describe('DIDDataStore', () => {
         let record: TileDocument | null = null
         const id = 'did:test:123'
         const update = jest.fn()
-        const cache = jest.fn(() => true)
         const deterministic = jest.fn((_ceramic, _content, metadata, _opts) => {
           record = { id: 'streamId', update, metadata } as unknown as TileDocument
           return Promise.resolve(record)
         })
-        Loader.mockImplementationOnce(() => ({ deterministic, cache } as unknown as TileLoader))
+        Loader.mockImplementationOnce(() => ({ deterministic } as unknown as TileLoader))
 
         const ceramic = { did: { id } }
         const ds = new DIDDataStore({ ceramic, model } as any)
@@ -692,16 +684,14 @@ describe('DIDDataStore', () => {
         // eslint-disable-next-line @typescript-eslint/unbound-method
         expect(deterministic).toBeCalledWith({ controllers: [id], family: 'defId' })
         expect(update).toBeCalledWith(content, { schema: 'schemaId' }, { pin: true })
-        expect(cache).toBeCalledWith(record)
       })
 
       test('pin by default', async () => {
-        const cache = jest.fn(() => true)
         const update = jest.fn()
         const deterministic = jest.fn((_ceramic, _content, metadata, _opts) => {
           return Promise.resolve({ id: 'streamId', update, metadata } as unknown as TileDocument)
         })
-        Loader.mockImplementationOnce(() => ({ deterministic, cache } as unknown as TileLoader))
+        Loader.mockImplementationOnce(() => ({ deterministic } as unknown as TileLoader))
 
         const ds = new DIDDataStore({
           ceramic: { did: { id: 'did:test:123' } },
@@ -712,12 +702,11 @@ describe('DIDDataStore', () => {
       })
 
       test('no pinning by setting instance option', async () => {
-        const cache = jest.fn(() => true)
         const update = jest.fn()
         const deterministic = jest.fn((_ceramic, _content, metadata, _opts) => {
           return Promise.resolve({ id: 'streamId', update, metadata } as unknown as TileDocument)
         })
-        Loader.mockImplementationOnce(() => ({ deterministic, cache } as unknown as TileLoader))
+        Loader.mockImplementationOnce(() => ({ deterministic } as unknown as TileLoader))
 
         const ds = new DIDDataStore({
           autopin: false,

--- a/packages/tile-loader/package.json
+++ b/packages/tile-loader/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@glazed/tile-loader",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "author": "3Box Labs",
   "license": "(Apache-2.0 OR MIT)",
   "homepage": "https://github.com/ceramicstudio/js-glaze#readme",

--- a/packages/tile-loader/src/index.ts
+++ b/packages/tile-loader/src/index.ts
@@ -14,11 +14,13 @@ import type {
   CreateOpts,
   GenesisCommit,
   MultiQuery,
+  UpdateOpts,
 } from '@ceramicnetwork/common'
 import { TileDocument } from '@ceramicnetwork/stream-tile'
 import type { TileMetadataArgs } from '@ceramicnetwork/stream-tile'
 import { CommitID, StreamID, StreamRef } from '@ceramicnetwork/streamid'
 import DataLoader from 'dataloader'
+import type { BatchLoadFn } from 'dataloader'
 
 /**
  * Omit `path` and `atTime` from [MultiQuery](https://developers.ceramic.network/reference/typescript/interfaces/_ceramicnetwork_common.multiquery-1.html) as the cache needs to be deterministic based on the ID.
@@ -89,6 +91,8 @@ export async function getDeterministicQuery(metadata: TileMetadataArgs): Promise
   return { genesis, streamId }
 }
 
+const tempBatchLoadFn: BatchLoadFn<TileKey, TileDocument> = () => Promise.resolve([])
+
 /**
  * A TileLoader extends [DataLoader](https://github.com/graphql/dataloader) to provide batching and caching functionalities for loading TileDocument streams.
  */
@@ -97,26 +101,27 @@ export class TileLoader extends DataLoader<TileKey, TileDocument> {
   #useCache: boolean
 
   constructor(params: TileLoaderParams) {
-    super(
-      async (keys) => {
-        if (!params.cache) {
-          // Disable cache but keep batching behavior - from https://github.com/graphql/dataloader#disabling-cache
-          this.clearAll()
-        }
-        const results = await params.ceramic.multiQuery(keys.map(keyToQuery))
-        return keys.map((key) => {
-          const id = keyToString(key)
-          const doc = results[id]
-          return doc ? (doc as TileDocument) : new Error(`Failed to load stream: ${id}`)
-        })
-      },
-      {
-        cache: true, // Cache needs to be enabled for batching
-        cacheKeyFn: keyToString,
-        cacheMap:
-          params.cache != null && typeof params.cache !== 'boolean' ? params.cache : undefined,
+    super(tempBatchLoadFn, {
+      cache: true, // Cache needs to be enabled for batching
+      cacheKeyFn: keyToString,
+      cacheMap:
+        params.cache != null && typeof params.cache !== 'boolean' ? params.cache : undefined,
+    })
+
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore internal method
+    this._batchLoadFn = async (keys: ReadonlyArray<TileKey>) => {
+      if (!params.cache) {
+        // Disable cache but keep batching behavior - from https://github.com/graphql/dataloader#disabling-cache
+        this.clearAll()
       }
-    )
+      const results = await params.ceramic.multiQuery(keys.map(keyToQuery))
+      return keys.map((key) => {
+        const id = keyToString(key)
+        const doc = results[id]
+        return doc ? (doc as TileDocument) : new Error(`Failed to load stream: ${id}`)
+      })
+    }
 
     this.#ceramic = params.ceramic
     this.#useCache = !!params.cache
@@ -176,5 +181,21 @@ export class TileLoader extends DataLoader<TileKey, TileDocument> {
     key: TileKey
   ): Promise<TileDocument<T>> {
     return (await super.load(key)) as TileDocument<T>
+  }
+
+  /**
+   * Update a TileDocument after loading the stream remotely, bypassing the cache.
+   */
+  async update<T extends Record<string, any> = Record<string, any>>(
+    streamID: string | StreamID,
+    content?: T,
+    metadata?: TileMetadataArgs,
+    options?: UpdateOpts
+  ): Promise<TileDocument<T | null | undefined>> {
+    const id = keyToString(streamID)
+    this.clear(id)
+    const stream = await this.load<T>({ streamId: id })
+    await stream.update(content, metadata, options)
+    return stream
   }
 }

--- a/packages/tile-loader/test/lib.test.ts
+++ b/packages/tile-loader/test/lib.test.ts
@@ -2,7 +2,7 @@ import type { CeramicApi, CeramicSigner, GenesisCommit } from '@ceramicnetwork/c
 import { TileDocument } from '@ceramicnetwork/stream-tile'
 import { CommitID, StreamID } from '@ceramicnetwork/streamid'
 
-import { TileLoader, getDeterministicQuery, keyToQuery, keyToString } from '../src'
+import { type TileCache, TileLoader, getDeterministicQuery, keyToQuery, keyToString } from '../src'
 
 describe('tile-loader', () => {
   const testCID = 'bagcqcerakszw2vsovxznyp5gfnpdj4cqm2xiv76yd24wkjewhhykovorwo6a'
@@ -238,6 +238,39 @@ describe('tile-loader', () => {
           options
         )
       })
+    })
+
+    test('update() method removes the stream from the cache before loading and updating', async () => {
+      const cacheMap = new Map<string, Promise<TileDocument>>()
+      const cacheDelete = jest.fn((key: string) => cacheMap.delete(key))
+      const cacheSet = jest.fn((key: string, value: Promise<TileDocument>) => {
+        return cacheMap.set(key, value)
+      })
+      const cache: TileCache = {
+        clear: () => cacheMap.clear(),
+        get: (key) => cacheMap.get(key),
+        delete: cacheDelete,
+        set: cacheSet,
+      }
+
+      const update = jest.fn()
+      const multiQuery = jest.fn(() => ({ [testID1]: { update } }))
+
+      const loader = new TileLoader({
+        cache,
+        ceramic: { multiQuery } as unknown as CeramicApi,
+      })
+
+      await loader.load(testID1)
+      expect(cacheDelete).not.toBeCalled()
+      expect(cacheMap.has(testID1)).toBe(true)
+      expect(cacheSet).toBeCalledTimes(1)
+
+      await loader.update(testID1, { test: true }, { schema: 'foo' }, { pin: true })
+      expect(update).toBeCalledWith({ test: true }, { schema: 'foo' }, { pin: true })
+      expect(cacheDelete).toBeCalledWith(testID1)
+      expect(cacheMap.has(testID1)).toBe(true)
+      expect(cacheSet).toBeCalledTimes(2)
     })
   })
 })


### PR DESCRIPTION
## Description

Force loading streams before updates when cached by TileLoader

## How Has This Been Tested?

Added unit tests