### PR TITLE
feat: add multi query timeout as config option

### DIFF
--- a/packages/tile-loader/src/index.ts
+++ b/packages/tile-loader/src/index.ts
@@ -57,7 +57,11 @@ export type TileLoaderParams = {
   /**
    * A supported cache implementation, `true` to use the default implementation or `false` to disable the cache (default)
    */
-  cache?: TileCache | boolean
+  cache?: TileCache | boolean, 
+  /**
+   * MultiQuery request timeout in milliseconds 
+   */
+  multiqueryTimeout?: number
 }
 
 /** @internal */
@@ -115,7 +119,7 @@ export class TileLoader extends DataLoader<TileKey, TileDocument> {
         // Disable cache but keep batching behavior - from https://github.com/graphql/dataloader#disabling-cache
         this.clearAll()
       }
-      const results = await params.ceramic.multiQuery(keys.map(keyToQuery))
+      const results = await params.ceramic.multiQuery(keys.map(keyToQuery), params.multiqueryTimeout)
       return keys.map((key) => {
         const id = keyToString(key)
         const doc = results[id]

--- a/packages/tile-loader/test/lib.test.ts
+++ b/packages/tile-loader/test/lib.test.ts
@@ -4,6 +4,8 @@ import { CommitID, StreamID } from '@ceramicnetwork/streamid'
 
 import { type TileCache, TileLoader, getDeterministicQuery, keyToQuery, keyToString } from '../src'
 
+const multiqueryTimeout = 2000
+
 describe('tile-loader', () => {
   const testCID = 'bagcqcerakszw2vsovxznyp5gfnpdj4cqm2xiv76yd24wkjewhhykovorwo6a'
   const testCommitID = new CommitID(1, testCID)
@@ -73,10 +75,10 @@ describe('tile-loader', () => {
   describe('TileLoader', () => {
     test('provides batching', async () => {
       const multiQuery = jest.fn(() => ({ [testID1]: {}, [testID2]: {} }))
-      const loader = new TileLoader({ ceramic: { multiQuery } as unknown as CeramicApi })
+      const loader = new TileLoader({ ceramic: { multiQuery } as unknown as CeramicApi, multiqueryTimeout})
       await Promise.all([loader.load(testID1), loader.load(testID2)])
       expect(multiQuery).toBeCalledTimes(1)
-      expect(multiQuery).toBeCalledWith([{ streamId: testID1 }, { streamId: testID2 }])
+      expect(multiQuery).toBeCalledWith([{ streamId: testID1 }, { streamId: testID2 }], multiqueryTimeout)
     })
 
     test('throws if one of the streams is not found', async () => {
@@ -98,14 +100,14 @@ describe('tile-loader', () => {
 
     test('does not cache by default', async () => {
       const multiQuery = jest.fn(() => ({ [testID1]: {}, [testID2]: {} }))
-      const loader = new TileLoader({ ceramic: { multiQuery } as unknown as CeramicApi })
+      const loader = new TileLoader({ ceramic: { multiQuery } as unknown as CeramicApi, multiqueryTimeout })
 
       await loader.load(testID1)
       expect(multiQuery).toBeCalledTimes(1)
 
       await Promise.all([loader.load(testID1), loader.load(testID2)])
       expect(multiQuery).toBeCalledTimes(2)
-      expect(multiQuery).toHaveBeenLastCalledWith([{ streamId: testID1 }, { streamId: testID2 }])
+      expect(multiQuery).toHaveBeenLastCalledWith([{ streamId: testID1 }, { streamId: testID2 }], multiqueryTimeout)
     })
 
     test('has opt-in cache', async () => {
@@ -113,6 +115,7 @@ describe('tile-loader', () => {
       const loader = new TileLoader({
         cache: true,
         ceramic: { multiQuery } as unknown as CeramicApi,
+        multiqueryTimeout
       })
 
       await loader.load(testID1)
@@ -120,7 +123,7 @@ describe('tile-loader', () => {
 
       await Promise.all([loader.load(testID1), loader.load(testID2)])
       expect(multiQuery).toBeCalledTimes(2)
-      expect(multiQuery).toHaveBeenLastCalledWith([{ streamId: testID2 }])
+      expect(multiQuery).toHaveBeenLastCalledWith([{ streamId: testID2 }], multiqueryTimeout)
     })
 
     test('use provided cache', async () => {
@@ -129,6 +132,7 @@ describe('tile-loader', () => {
       const loader = new TileLoader({
         cache,
         ceramic: { multiQuery } as unknown as CeramicApi,
+        multiqueryTimeout
       })
 
       await loader.load(testID1)
@@ -138,7 +142,7 @@ describe('tile-loader', () => {
 
       await Promise.all([loader.load(testID1), loader.load(testID2)])
       expect(multiQuery).toBeCalledTimes(2)
-      expect(multiQuery).toHaveBeenLastCalledWith([{ streamId: testID1 }, { streamId: testID2 }])
+      expect(multiQuery).toHaveBeenLastCalledWith([{ streamId: testID1 }, { streamId: testID2 }], multiqueryTimeout)
       expect(cache.has(testID1)).toBe(true)
       expect(cache.has(testID2)).toBe(true)
     })
@@ -207,10 +211,11 @@ describe('tile-loader', () => {
         const multiQuery = jest.fn(() => ({ [streamId.toString()]: stream }))
         const loader = new TileLoader({
           ceramic: { createStreamFromGenesis, multiQuery } as unknown as CeramicApi,
+          multiqueryTimeout
         })
 
         await expect(loader.deterministic(metadata)).resolves.toBe(stream)
-        expect(multiQuery).toBeCalledWith([{ streamId, genesis }])
+        expect(multiQuery).toBeCalledWith([{ streamId, genesis }], multiqueryTimeout)
         expect(createStreamFromGenesis).not.toBeCalled()
       })
 
@@ -227,11 +232,12 @@ describe('tile-loader', () => {
         const multiQuery = jest.fn(() => ({}))
         const loader = new TileLoader({
           ceramic: { createStreamFromGenesis, multiQuery } as unknown as CeramicApi,
+          multiqueryTimeout
         })
 
         const options = { anchor: false, pin: true, publish: false, sync: 0 }
         await expect(loader.deterministic(metadata, options)).resolves.toBe(stream)
-        expect(multiQuery).toBeCalledWith([{ streamId, genesis }])
+        expect(multiQuery).toBeCalledWith([{ streamId, genesis }], multiqueryTimeout)
         expect(createStreamFromGenesis).toBeCalledWith(
           TileDocument.STREAM_TYPE_ID,
           genesis,


### PR DESCRIPTION
Added option to pass through the multiquery timeout and updated tests. 

Timeout control is a bit hard maybe with the batching, ie i have a set of i want to timeout quickly and another i want to timeout slowly. In general this is hard to achieve with a multiquery as well. 

Not relevant to this library, but also seems likes multiquery timeout is not be handled as expected, default is 7 sec, but seeing stream default of 3 seconds. 
