### PR TITLE
Include secure JSON schema for validation in devtools 

### DIFF
--- a/packages/devtools/package.json
+++ b/packages/devtools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@glazed/devtools",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "author": "3Box Labs",
   "license": "(Apache-2.0 OR MIT)",
   "homepage": "https://github.com/ceramicstudio/js-glaze#readme",

--- a/packages/devtools/src/validation.ts
+++ b/packages/devtools/src/validation.ts
@@ -1,13 +1,101 @@
 import Ajv from 'ajv'
 import type { JSONSchemaType } from 'ajv'
 import addFormats from 'ajv-formats'
-import SecureSchema from 'ajv/lib/refs/json-schema-secure.json'
 
 /**
- * Seems the secure schema is not strict, this causes warnings to be logged
+ * Compile the schema from ajv/lib/refs/json-schema-secure.json, copied to avoid JSON import.
+ * Seems the secure schema is not strict, this causes warnings to be logged.
  *
  * @internal */
-export const validateSchemaSecure = new Ajv({ strict: false }).compile(SecureSchema)
+export const validateSchemaSecure = new Ajv({ strict: false }).compile({
+  $schema: 'http://json-schema.org/draft-07/schema#',
+  $id: 'https://raw.githubusercontent.com/ajv-validator/ajv/master/lib/refs/json-schema-secure.json#',
+  title: 'Meta-schema for the security assessment of JSON Schemas',
+  description:
+    'If a JSON AnySchema fails validation against this meta-schema, it may be unsafe to validate untrusted data',
+  definitions: {
+    schemaArray: {
+      type: 'array',
+      minItems: 1,
+      items: { $ref: '#' },
+    },
+  },
+  dependencies: {
+    patternProperties: {
+      description: 'prevent slow validation of large property names',
+      required: ['propertyNames'],
+      properties: {
+        propertyNames: {
+          required: ['maxLength'],
+        },
+      },
+    },
+    uniqueItems: {
+      description: 'prevent slow validation of large non-scalar arrays',
+      if: {
+        properties: {
+          uniqueItems: { const: true },
+          items: {
+            properties: {
+              type: {
+                anyOf: [
+                  {
+                    enum: ['object', 'array'],
+                  },
+                  {
+                    type: 'array',
+                    contains: { enum: ['object', 'array'] },
+                  },
+                ],
+              },
+            },
+          },
+        },
+      },
+      then: {
+        required: ['maxItems'],
+      },
+    },
+    pattern: {
+      description: 'prevent slow pattern matching of large strings',
+      required: ['maxLength'],
+    },
+    format: {
+      description: 'prevent slow format validation of large strings',
+      required: ['maxLength'],
+    },
+  },
+  properties: {
+    additionalItems: { $ref: '#' },
+    additionalProperties: { $ref: '#' },
+    dependencies: {
+      additionalProperties: {
+        anyOf: [{ type: 'array' }, { $ref: '#' }],
+      },
+    },
+    items: {
+      anyOf: [{ $ref: '#' }, { $ref: '#/definitions/schemaArray' }],
+    },
+    definitions: {
+      additionalProperties: { $ref: '#' },
+    },
+    patternProperties: {
+      additionalProperties: { $ref: '#' },
+    },
+    properties: {
+      additionalProperties: { $ref: '#' },
+    },
+    if: { $ref: '#' },
+    then: { $ref: '#' },
+    else: { $ref: '#' },
+    allOf: { $ref: '#/definitions/schemaArray' },
+    anyOf: { $ref: '#/definitions/schemaArray' },
+    oneOf: { $ref: '#/definitions/schemaArray' },
+    not: { $ref: '#' },
+    contains: { $ref: '#' },
+    propertyNames: { $ref: '#' },
+  },
+})
 
 export function isSecureSchema<T = Record<string, any>>(schema: JSONSchemaType<T>): boolean {
   const ajv = new Ajv()


### PR DESCRIPTION
## Description

Include schema directly in code rather than using a JSON import, should fix https://github.com/ceramicstudio/self.id/issues/58

## How Has This Been Tested?

Linked locally and checked with glaze-demo-app publish script.
