### PR TITLE
Exposed sync options in tiles:show cli command

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -396,7 +396,7 @@ ARGUMENTS
 
 OPTIONS
   -c, --ceramic=ceramic  Ceramic API URL
-  -s, --syncOption  Controls if the current stream state should be synced over the network or not. 'prefer-cache' will return the state from the node's local cache if present, and will sync from the network if the stream isn't in the cache. 'always-sync' always syncs from the network, even if there is cached state for the stream. 'never-sync' never syncs from the network.
+  -s, --sync  Controls if the current stream state should be synced over the network or not. 'prefer-cache' will return the state from the node's local cache if present, and will sync from the network if the stream isn't in the cache. 'always-sync' always syncs from the network, even if there is cached state for the stream. 'never-sync' never syncs from the network.
 ```
 
 ### `glaze stream:state STREAMID`
@@ -412,7 +412,7 @@ ARGUMENTS
 
 OPTIONS
   -c, --ceramic=ceramic  Ceramic API URL
-  -s, --syncOption  Controls if the current stream state should be synced over the network or not. 'prefer-cache' will return the state from the node's local cache if present, and will sync from the network if the stream isn't in the cache. 'always-sync' always syncs from the network, even if there is cached state for the stream. 'never-sync' never syncs from the network.
+  -s, --sync  Controls if the current stream state should be synced over the network or not. 'prefer-cache' will return the state from the node's local cache if present, and will sync from the network if the stream isn't in the cache. 'always-sync' always syncs from the network, even if there is cached state for the stream. 'never-sync' never syncs from the network.
 ```
 
 ### `glaze tile:create`
@@ -444,7 +444,7 @@ ARGUMENTS
 OPTIONS
   -c, --ceramic=ceramic  Ceramic API URL
   -k, --key=key          DID Private Key
-  -s, --syncOption  Controls if the current stream state should be synced over the network or not. 'prefer-cache' will return the state from the node's local cache if present, and will sync from the network if the stream isn't in the cache. 'always-sync' always syncs from the network, even if there is cached state for the stream. 'never-sync' never syncs from the network.
+  -s, --sync  Controls if the current stream state should be synced over the network or not. 'prefer-cache' will return the state from the node's local cache if present, and will sync from the network if the stream isn't in the cache. 'always-sync' always syncs from the network, even if there is cached state for the stream. 'never-sync' never syncs from the network.
 ```
 
 ### `glaze tile:content STREAMID`
@@ -460,7 +460,7 @@ ARGUMENTS
 
 OPTIONS
   -c, --ceramic=ceramic  Ceramic API URL
-  -s, --syncOption  Controls if the current stream state should be synced over the network or not. 'prefer-cache' will return the state from the node's local cache if present, and will sync from the network if the stream isn't in the cache. 'always-sync' always syncs from the network, even if there is cached state for the stream. 'never-sync' never syncs from the network.
+  -s, --sync  Controls if the current stream state should be synced over the network or not. 'prefer-cache' will return the state from the node's local cache if present, and will sync from the network if the stream isn't in the cache. 'always-sync' always syncs from the network, even if there is cached state for the stream. 'never-sync' never syncs from the network.
 ```
 
 ### `glaze tile:update STREAMID`
@@ -494,7 +494,7 @@ ARGUMENTS
 
 OPTIONS
   -c, --ceramic=ceramic  Ceramic API URL
-  -s, --syncOption  Controls if the current stream state should be synced over the network or not. 'prefer-cache' will return the state from the node's local cache if present, and will sync from the network if the stream isn't in the cache. 'always-sync' always syncs from the network, even if there is cached state for the stream. 'never-sync' never syncs from the network.
+  -s, --sync  Controls if the current stream state should be synced over the network or not. 'prefer-cache' will return the state from the node's local cache if present, and will sync from the network if the stream isn't in the cache. 'always-sync' always syncs from the network, even if there is cached state for the stream. 'never-sync' never syncs from the network.
 ```
 
 <!-- commandsstop -->

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -45,7 +45,7 @@ glaze COMMAND
 - [`glaze tile:deterministic METADATA`](#glaze-tiledeterministic-metadata)
 - [`glaze tile:content STREAMID`](#glaze-tileshow-streamid)
 - [`glaze tile:update STREAMID CONTENT`](#glaze-tileupdate-streamid-content)
-- [`glaze tile:watch STREAMID`](#glaze-tilewatch-streamid)
+- [`glaze tile:show STREAMID`](#glaze-tileshow-streamid)
 
 ### `glaze config:get KEY`
 
@@ -393,8 +393,10 @@ USAGE
 ARGUMENTS
   STREAMID  ID of the stream
 
+
 OPTIONS
   -c, --ceramic=ceramic  Ceramic API URL
+  -s, --syncOption  Controls if the current stream state should be synced over the network or not. 'prefer-cache' will return the state from the node's local cache if present, and will sync from the network if the stream isn't in the cache. 'always-sync' always syncs from the network, even if there is cached state for the stream. 'never-sync' never syncs from the network.
 ```
 
 ### `glaze stream:state STREAMID`
@@ -410,6 +412,7 @@ ARGUMENTS
 
 OPTIONS
   -c, --ceramic=ceramic  Ceramic API URL
+  -s, --syncOption  Controls if the current stream state should be synced over the network or not. 'prefer-cache' will return the state from the node's local cache if present, and will sync from the network if the stream isn't in the cache. 'always-sync' always syncs from the network, even if there is cached state for the stream. 'never-sync' never syncs from the network.
 ```
 
 ### `glaze tile:create`
@@ -441,6 +444,7 @@ ARGUMENTS
 OPTIONS
   -c, --ceramic=ceramic  Ceramic API URL
   -k, --key=key          DID Private Key
+  -s, --syncOption  Controls if the current stream state should be synced over the network or not. 'prefer-cache' will return the state from the node's local cache if present, and will sync from the network if the stream isn't in the cache. 'always-sync' always syncs from the network, even if there is cached state for the stream. 'never-sync' never syncs from the network.
 ```
 
 ### `glaze tile:content STREAMID`
@@ -456,6 +460,7 @@ ARGUMENTS
 
 OPTIONS
   -c, --ceramic=ceramic  Ceramic API URL
+  -s, --syncOption  Controls if the current stream state should be synced over the network or not. 'prefer-cache' will return the state from the node's local cache if present, and will sync from the network if the stream isn't in the cache. 'always-sync' always syncs from the network, even if there is cached state for the stream. 'never-sync' never syncs from the network.
 ```
 
 ### `glaze tile:update STREAMID`
@@ -474,6 +479,22 @@ OPTIONS
   -c, --ceramic=ceramic    Ceramic API URL
   -k, --key=key            DID Private Key
   -m, --metadata=metadata  Optional metadata for the stream
+```
+
+### `glaze tile:show STREAMID`
+
+show the contents of a Tile stream
+
+```
+USAGE
+  $ glaze tile:show STREAMID
+
+ARGUMENTS
+  STREAMID  ID of the stream
+
+OPTIONS
+  -c, --ceramic=ceramic  Ceramic API URL
+  -s, --syncOption  Controls if the current stream state should be synced over the network or not. 'prefer-cache' will return the state from the node's local cache if present, and will sync from the network if the stream isn't in the cache. 'always-sync' always syncs from the network, even if there is cached state for the stream. 'never-sync' never syncs from the network.
 ```
 
 <!-- commandsstop -->

--- a/packages/cli/src/command.ts
+++ b/packages/cli/src/command.ts
@@ -18,8 +18,16 @@ import { fromString } from 'uint8arrays'
 
 import { config } from './config.js'
 import { createDataModel, loadManagedModel } from './model.js'
+import { SyncOptions } from '@ceramicnetwork/common'
 
 type StringRecord = Record<string, unknown>
+
+// TODO: SYNC_OPTIONS_MAP is also used in js-ceramic/packages/cli. Move this const to '@ceramicnetwork/common'
+export const SYNC_OPTIONS_MAP: { [option: string]: SyncOptions | undefined } = {
+  'prefer-cache': SyncOptions.PREFER_CACHE,
+  'sync-always': SyncOptions.SYNC_ALWAYS,
+  'never-sync': SyncOptions.NEVER_SYNC,
+}
 
 export interface CommandFlags {
   ceramic?: string

--- a/packages/cli/src/command.ts
+++ b/packages/cli/src/command.ts
@@ -35,6 +35,10 @@ export interface CommandFlags {
   [key: string]: unknown
 }
 
+export type QueryCommandFlags = CommandFlags & {
+  sync?: SyncOptions
+}
+
 export const STREAM_ID_ARG = {
   name: 'streamId',
   required: true,

--- a/packages/cli/src/command.ts
+++ b/packages/cli/src/command.ts
@@ -23,7 +23,7 @@ import { SyncOptions } from '@ceramicnetwork/common'
 type StringRecord = Record<string, unknown>
 
 // TODO: SYNC_OPTIONS_MAP is also used in js-ceramic/packages/cli. Move this const to '@ceramicnetwork/common'
-export const SYNC_OPTIONS_MAP: { [option: string]: SyncOptions | undefined } = {
+export const SYNC_OPTIONS_MAP: Record<string, SyncOptions | undefined> = {
   'prefer-cache': SyncOptions.PREFER_CACHE,
   'sync-always': SyncOptions.SYNC_ALWAYS,
   'never-sync': SyncOptions.NEVER_SYNC,

--- a/packages/cli/src/command.ts
+++ b/packages/cli/src/command.ts
@@ -41,22 +41,12 @@ export const STREAM_ID_ARG = {
   description: 'ID of the stream',
 }
 
-async function parseSyncOption(input: string): Promise<SyncOptions> {
-  return new Promise((resolve, reject) => {
-    const syncOption = SYNC_OPTIONS_MAP[input]
-    if (syncOption) {
-      resolve(syncOption)
-    } else {
-      reject()
-    }
-  })
-}
-
 export const SYNC_OPTION_FLAG = Flags.integer({
   char: 's',
+  required: false,
   options: Object.keys(SYNC_OPTIONS_MAP),
   description: `Controls if the current stream state should be synced over the network or not. 'prefer-cache' will return the state from the node's local cache if present, and will sync from the network if the stream isn't in the cache. 'always-sync' always syncs from the network, even if there is cached state for the stream. 'never-sync' never syncs from the network.`,
-  parse: parseSyncOption
+  parse: (input: string) => { return Promise.resolve(SYNC_OPTIONS_MAP[input] ?? SyncOptions.PREFER_CACHE) }
 })
 
 export abstract class Command<

--- a/packages/cli/src/command.ts
+++ b/packages/cli/src/command.ts
@@ -35,6 +35,30 @@ export interface CommandFlags {
   [key: string]: unknown
 }
 
+export const STREAM_ID_ARG = {
+  name: 'streamId',
+  required: true,
+  description: 'ID of the stream',
+}
+
+async function parseSyncOption(input: string): Promise<SyncOptions> {
+  return new Promise((resolve, reject) => {
+    const syncOption = SYNC_OPTIONS_MAP[input]
+    if (syncOption) {
+      resolve(syncOption)
+    } else {
+      reject()
+    }
+  })
+}
+
+export const SYNC_OPTION_FLAG = Flags.integer({
+  char: 's',
+  options: Object.keys(SYNC_OPTIONS_MAP),
+  description: `Controls if the current stream state should be synced over the network or not. 'prefer-cache' will return the state from the node's local cache if present, and will sync from the network if the stream isn't in the cache. 'always-sync' always syncs from the network, even if there is cached state for the stream. 'never-sync' never syncs from the network.`,
+  parse: parseSyncOption
+})
+
 export abstract class Command<
   Flags extends CommandFlags = CommandFlags,
   Args extends StringRecord = StringRecord

--- a/packages/cli/src/commands/stream/commits.ts
+++ b/packages/cli/src/commands/stream/commits.ts
@@ -7,7 +7,7 @@ import {
 } from '../../command.js'
 
 type Flags = CommandFlags & {
-  syncOption?: SyncOptions
+  sync?: SyncOptions
 }
 
 export default class Commits extends Command<Flags, { streamId: string }> {
@@ -19,7 +19,7 @@ export default class Commits extends Command<Flags, { streamId: string }> {
 
   static flags = {
     ...Command.flags,
-    syncOption: SYNC_OPTION_FLAG,
+    sync: SYNC_OPTION_FLAG,
   }
 
   async run(): Promise<void> {
@@ -27,7 +27,7 @@ export default class Commits extends Command<Flags, { streamId: string }> {
     try {
       const stream = await this.ceramic.loadStream(
         this.args.streamId,
-        { sync: this.flags.syncOption }
+        { sync: this.flags.sync }
       )
       const commits = stream.allCommitIds.map((v) => v.toString())
       this.spinner.succeed(`Stream commits loaded.`)

--- a/packages/cli/src/commands/stream/commits.ts
+++ b/packages/cli/src/commands/stream/commits.ts
@@ -1,16 +1,11 @@
-import { SyncOptions } from '@ceramicnetwork/common'
 import { 
   Command, 
   STREAM_ID_ARG,
   SYNC_OPTION_FLAG,
-  type CommandFlags
+  type QueryCommandFlags
 } from '../../command.js'
 
-type Flags = CommandFlags & {
-  sync?: SyncOptions
-}
-
-export default class Commits extends Command<Flags, { streamId: string }> {
+export default class Commits extends Command<QueryCommandFlags, { streamId: string }> {
   static description = 'list commits contained within a stream'
 
   static args = [

--- a/packages/cli/src/commands/stream/commits.ts
+++ b/packages/cli/src/commands/stream/commits.ts
@@ -1,22 +1,36 @@
-import { Command, type CommandFlags } from '../../command.js'
+import { SyncOptions } from '@ceramicnetwork/common'
+import { 
+  Command, 
+  STREAM_ID_ARG,
+  SYNC_OPTION_FLAG,
+  type CommandFlags
+} from '../../command.js'
 
-export default class Commits extends Command<CommandFlags, { streamId: string }> {
+type Flags = CommandFlags & {
+  syncOption?: SyncOptions
+}
+
+export default class Commits extends Command<Flags, { streamId: string }> {
   static description = 'list commits contained within a stream'
 
   static args = [
-    {
-      name: 'streamId',
-      description: 'ID of the stream',
-      required: true,
-    },
+    STREAM_ID_ARG,
   ]
+
+  static flags = {
+    ...Command.flags,
+    syncOption: SYNC_OPTION_FLAG,
+  }
 
   async run(): Promise<void> {
     this.spinner.start(`Loading stream ${this.args.streamId}...`)
     try {
-      const stream = await this.ceramic.loadStream(this.args.streamId)
+      const stream = await this.ceramic.loadStream(
+        this.args.streamId,
+        { sync: this.flags.syncOption }
+      )
       const commits = stream.allCommitIds.map((v) => v.toString())
-      this.spinner.succeed('Stream commits loaded.')
+      this.spinner.succeed(`Stream commits loaded.`)
       this.logJSON(commits)
     } catch (e) {
       this.spinner.fail((e as Error).message)

--- a/packages/cli/src/commands/stream/state.ts
+++ b/packages/cli/src/commands/stream/state.ts
@@ -1,16 +1,11 @@
-import { SyncOptions } from '@ceramicnetwork/common'
 import { 
   Command,
   STREAM_ID_ARG,
   SYNC_OPTION_FLAG,
-  type CommandFlags
+  type QueryCommandFlags
 } from '../../command.js'
 
-type Flags = CommandFlags & {
-  sync?: SyncOptions
-}
-
-export default class State extends Command<Flags, { streamId: string }> {
+export default class State extends Command<QueryCommandFlags, { streamId: string }> {
   static description = 'get the state of a Stream'
 
   static args = [

--- a/packages/cli/src/commands/stream/state.ts
+++ b/packages/cli/src/commands/stream/state.ts
@@ -7,7 +7,7 @@ import {
 } from '../../command.js'
 
 type Flags = CommandFlags & {
-  syncOption?: SyncOptions
+  sync?: SyncOptions
 }
 
 export default class State extends Command<Flags, { streamId: string }> {
@@ -19,7 +19,7 @@ export default class State extends Command<Flags, { streamId: string }> {
 
   static flags = {
     ...Command.flags,
-    syncOption: SYNC_OPTION_FLAG,
+    sync: SYNC_OPTION_FLAG,
   }
 
   async run(): Promise<void> {
@@ -28,7 +28,7 @@ export default class State extends Command<Flags, { streamId: string }> {
     try {
       const stream = await this.ceramic.loadStream(
         this.args.streamId,
-        { sync: this.flags.syncOption }
+        { sync: this.flags.sync }
       )
       this.spinner.succeed(`Successfully queried stream ${this.args.streamId}.`)
       this.logJSON(stream.state)

--- a/packages/cli/src/commands/stream/state.ts
+++ b/packages/cli/src/commands/stream/state.ts
@@ -1,22 +1,36 @@
-import { Command, type CommandFlags } from '../../command.js'
+import { SyncOptions } from '@ceramicnetwork/common'
+import { 
+  Command,
+  STREAM_ID_ARG,
+  SYNC_OPTION_FLAG,
+  type CommandFlags
+} from '../../command.js'
 
-export default class State extends Command<CommandFlags, { streamId: string }> {
+type Flags = CommandFlags & {
+  syncOption?: SyncOptions
+}
+
+export default class State extends Command<Flags, { streamId: string }> {
   static description = 'get the state of a Stream'
 
   static args = [
-    {
-      name: 'streamId',
-      required: true,
-      description: 'ID of the Stream',
-    },
+    STREAM_ID_ARG,
   ]
+
+  static flags = {
+    ...Command.flags,
+    syncOption: SYNC_OPTION_FLAG,
+  }
 
   async run(): Promise<void> {
     this.spinner.start(`Querying stream ${this.args.streamId}`)
 
     try {
-      const stream = await this.ceramic.loadStream(this.args.streamId)
-      this.spinner.succeed(`Successfully queried stream ${this.args.streamId}`)
+      const stream = await this.ceramic.loadStream(
+        this.args.streamId,
+        { sync: this.flags.syncOption }
+      )
+      this.spinner.succeed(`Successfully queried stream ${this.args.streamId}.`)
       this.logJSON(stream.state)
     } catch (e) {
       this.spinner.fail((e as Error).message)

--- a/packages/cli/src/commands/tile/content.ts
+++ b/packages/cli/src/commands/tile/content.ts
@@ -9,7 +9,7 @@ import {
 } from '../../command.js'
 
 type Flags = CommandFlags & {
-  syncOption?: SyncOptions
+  sync?: SyncOptions
 }
 
 export default class ShowTile extends Command<Flags, { streamId: string }> {
@@ -21,7 +21,7 @@ export default class ShowTile extends Command<Flags, { streamId: string }> {
 
   static flags = {
     ...Command.flags,
-    syncOption: SYNC_OPTION_FLAG,
+    sync: SYNC_OPTION_FLAG,
   }
 
   async run(): Promise<void> {
@@ -30,7 +30,7 @@ export default class ShowTile extends Command<Flags, { streamId: string }> {
       const stream = await TileDocument.load(
         this.ceramic, 
         this.args.streamId,
-        { sync: this.flags.syncOption }
+        { sync: this.flags.sync }
       )
       this.spinner.succeed(`Retrieved details of stream ${this.args.streamId}.`)
       this.logJSON(stream.content)

--- a/packages/cli/src/commands/tile/content.ts
+++ b/packages/cli/src/commands/tile/content.ts
@@ -1,18 +1,13 @@
-import { SyncOptions } from '@ceramicnetwork/common'
 import { TileDocument } from '@ceramicnetwork/stream-tile'
 
 import { 
   Command, 
-  type CommandFlags,
+  type QueryCommandFlags,
   STREAM_ID_ARG,
   SYNC_OPTION_FLAG
 } from '../../command.js'
 
-type Flags = CommandFlags & {
-  sync?: SyncOptions
-}
-
-export default class ShowTile extends Command<Flags, { streamId: string }> {
+export default class ShowTile extends Command<QueryCommandFlags, { streamId: string }> {
   static description = 'show the contents of a Tile stream'
 
   static args = [

--- a/packages/cli/src/commands/tile/content.ts
+++ b/packages/cli/src/commands/tile/content.ts
@@ -4,6 +4,7 @@ import { TileDocument } from '@ceramicnetwork/stream-tile'
 import { 
   Command, 
   type CommandFlags,
+  STREAM_ID_ARG,
   SYNC_OPTION_FLAG
 } from '../../command.js'
 
@@ -15,11 +16,7 @@ export default class ShowTile extends Command<Flags, { streamId: string }> {
   static description = 'show the contents of a Tile stream'
 
   static args = [
-    {
-      name: 'streamId',
-      required: true,
-      description: 'ID of the stream',
-    },
+    STREAM_ID_ARG,
   ]
 
   static flags = {

--- a/packages/cli/src/commands/tile/content.ts
+++ b/packages/cli/src/commands/tile/content.ts
@@ -1,8 +1,17 @@
+import { SyncOptions } from '@ceramicnetwork/common'
 import { TileDocument } from '@ceramicnetwork/stream-tile'
 
-import { Command, type CommandFlags } from '../../command.js'
+import { 
+  Command, 
+  type CommandFlags,
+  SYNC_OPTION_FLAG
+} from '../../command.js'
 
-export default class ShowTile extends Command<CommandFlags, { streamId: string }> {
+type Flags = CommandFlags & {
+  syncOption?: SyncOptions
+}
+
+export default class ShowTile extends Command<Flags, { streamId: string }> {
   static description = 'show the contents of a Tile stream'
 
   static args = [
@@ -13,11 +22,20 @@ export default class ShowTile extends Command<CommandFlags, { streamId: string }
     },
   ]
 
+  static flags = {
+    ...Command.flags,
+    syncOption: SYNC_OPTION_FLAG,
+  }
+
   async run(): Promise<void> {
     this.spinner.start(`Loading stream ${this.args.streamId}`)
     try {
-      const stream = await TileDocument.load(this.ceramic, this.args.streamId)
-      this.spinner.succeed(`Retrieved details of stream ${this.args.streamId}`)
+      const stream = await TileDocument.load(
+        this.ceramic, 
+        this.args.streamId,
+        { sync: this.flags.syncOption }
+      )
+      this.spinner.succeed(`Retrieved details of stream ${this.args.streamId}.`)
       this.logJSON(stream.content)
     } catch (e) {
       this.spinner.fail((e as Error).message)

--- a/packages/cli/src/commands/tile/deterministic.ts
+++ b/packages/cli/src/commands/tile/deterministic.ts
@@ -1,18 +1,13 @@
-import { SyncOptions } from '@ceramicnetwork/common'
 import { TileDocument, type TileMetadataArgs } from '@ceramicnetwork/stream-tile'
 
 import { 
   Command,
-  type CommandFlags,
+  type QueryCommandFlags,
   SYNC_OPTION_FLAG
 } from '../../command.js'
 
-type Flags = CommandFlags & {
-  sync?: SyncOptions
-}
-
 export default class DeterministicTile extends Command<
-  Flags,
+  QueryCommandFlags,
   { metadata: TileMetadataArgs }
 > {
   static description = 'load a deterministic Tile stream'

--- a/packages/cli/src/commands/tile/deterministic.ts
+++ b/packages/cli/src/commands/tile/deterministic.ts
@@ -1,9 +1,18 @@
+import { SyncOptions } from '@ceramicnetwork/common'
 import { TileDocument, type TileMetadataArgs } from '@ceramicnetwork/stream-tile'
 
-import { Command, type CommandFlags } from '../../command.js'
+import { 
+  Command,
+  type CommandFlags,
+  SYNC_OPTION_FLAG
+} from '../../command.js'
+
+type Flags = CommandFlags & {
+  syncOption?: SyncOptions
+}
 
 export default class DeterministicTile extends Command<
-  CommandFlags,
+  Flags,
   { metadata: TileMetadataArgs }
 > {
   static description = 'load a deterministic Tile stream'
@@ -19,13 +28,19 @@ export default class DeterministicTile extends Command<
 
   static flags = {
     ...Command.flags,
+    syncOption: SYNC_OPTION_FLAG,
   }
   async run(): Promise<void> {
     this.spinner.start('Loading stream...')
 
     try {
-      const tile = await TileDocument.deterministic(this.ceramic, this.args.metadata)
-      this.spinner.succeed(`Loaded tile ${tile.id.toString()}.`)
+      const tile = await TileDocument.deterministic(
+        this.ceramic,
+        this.args.metadata,
+        { sync: this.flags.syncOption }
+      )
+      this.spinner.succeed(`
+        Loaded tile ${tile.id.toString()}.`)
       this.logJSON({
         streamID: tile.id.toString(),
         content: tile.content,

--- a/packages/cli/src/commands/tile/deterministic.ts
+++ b/packages/cli/src/commands/tile/deterministic.ts
@@ -8,7 +8,7 @@ import {
 } from '../../command.js'
 
 type Flags = CommandFlags & {
-  syncOption?: SyncOptions
+  sync?: SyncOptions
 }
 
 export default class DeterministicTile extends Command<
@@ -28,7 +28,7 @@ export default class DeterministicTile extends Command<
 
   static flags = {
     ...Command.flags,
-    syncOption: SYNC_OPTION_FLAG,
+    sync: SYNC_OPTION_FLAG,
   }
   async run(): Promise<void> {
     this.spinner.start('Loading stream...')
@@ -37,7 +37,7 @@ export default class DeterministicTile extends Command<
       const tile = await TileDocument.deterministic(
         this.ceramic,
         this.args.metadata,
-        { sync: this.flags.syncOption }
+        { sync: this.flags.sync }
       )
       this.spinner.succeed(`
         Loaded tile ${tile.id.toString()}.`)

--- a/packages/cli/src/commands/tile/show.ts
+++ b/packages/cli/src/commands/tile/show.ts
@@ -4,7 +4,8 @@ import { TileDocument } from '@ceramicnetwork/stream-tile'
 import { 
   Command, 
   type CommandFlags,
-  SYNC_OPTION_FLAG
+  SYNC_OPTION_FLAG,
+  STREAM_ID_ARG
 } from '../../command.js'
 
 type Flags = CommandFlags & {
@@ -15,11 +16,7 @@ export default class ShowTile extends Command<Flags, { streamId: string }> {
   static description = 'show the contents of a Tile stream'
 
   static args = [
-    {
-      name: 'streamId',
-      required: true,
-      description: 'ID of the stream',
-    },
+    STREAM_ID_ARG,
   ]
 
   static flags = {

--- a/packages/cli/src/commands/tile/show.ts
+++ b/packages/cli/src/commands/tile/show.ts
@@ -9,7 +9,7 @@ import {
 } from '../../command.js'
 
 type Flags = CommandFlags & {
-  syncOption?: SyncOptions
+  sync?: SyncOptions
 }
 
 export default class ShowTile extends Command<Flags, { streamId: string }> {
@@ -21,7 +21,7 @@ export default class ShowTile extends Command<Flags, { streamId: string }> {
 
   static flags = {
     ...Command.flags,
-    syncOption: SYNC_OPTION_FLAG,
+    sync: SYNC_OPTION_FLAG,
   }
 
   async run(): Promise<void> {
@@ -30,7 +30,7 @@ export default class ShowTile extends Command<Flags, { streamId: string }> {
       const stream = await TileDocument.load(
         this.ceramic, 
         this.args.streamId,
-        { sync: this.flags.syncOption }
+        { sync: this.flags.sync }
       )
       
       this.spinner.succeed(`Retrieved details of stream ${this.args.streamId}.`)

--- a/packages/cli/src/commands/tile/show.ts
+++ b/packages/cli/src/commands/tile/show.ts
@@ -1,8 +1,28 @@
+import { SyncOptions } from '@ceramicnetwork/common/lib/streamopts'
 import { TileDocument } from '@ceramicnetwork/stream-tile'
 
-import { Command, type CommandFlags } from '../../command.js'
+import { 
+  Command, 
+  type CommandFlags,
+  SYNC_OPTIONS_MAP,
+} from '../../command.js'
 
-export default class ShowTile extends Command<CommandFlags, { streamId: string }> {
+type Flags = CommandFlags & {
+  syncOption?: SyncOptions
+}
+
+async function parseSyncOption(input: string): Promise<SyncOptions> {
+  return new Promise((resolve, reject) => {
+    const syncOption = SYNC_OPTIONS_MAP[input]
+    if (syncOption) {
+      resolve(syncOption)
+    } else {
+      reject()
+    }
+  })
+}
+
+export default class ShowTile extends Command<Flags, { streamId: string }> {
   static description = 'show the contents of a Tile stream'
 
   static args = [
@@ -11,13 +31,38 @@ export default class ShowTile extends Command<CommandFlags, { streamId: string }
       required: true,
       description: 'ID of the stream',
     },
+    {
+      name: 'sync',
+      required: false,
+      options: Object.keys(SYNC_OPTIONS_MAP),
+      description: `
+      Defines if the tile should be retrieved from node's cache, if it's available, always or never.
+      Available choices: 'prefer-cache', 'sync-always', 'sync-never'.
+      'prefer-cache' is the default
+      `
+    },
   ]
+
+  static flags = {
+    ...Command.flags,
+    syncOption: Flags.integer({
+      char: 's',
+      options: Object.keys(SYNC_OPTIONS_MAP),
+      description: `Controls if the current stream state should be synced over the network or not. 'prefer-cache' will return the state from the node's local cache if present, and will sync from the network if the stream isn't in the cache. 'always-sync' always syncs from the network, even if there is cached state for the stream. 'never-sync' never syncs from the network.`,
+      parse: parseSyncOption
+    }),
+  }
 
   async run(): Promise<void> {
     this.spinner.start(`Loading stream ${this.args.streamId}`)
     try {
-      const stream = await TileDocument.load(this.ceramic, this.args.streamId)
-      this.spinner.succeed(`Retrieved details of stream ${this.args.streamId}`)
+      const stream = await TileDocument.load(
+        this.ceramic, 
+        this.args.streamId,
+        { sync: this.flags.syncOption }
+      )
+      
+      this.spinner.succeed(`Retrieved details of stream ${this.args.streamId}.`)
       this.logJSON(stream.content)
     } catch (e) {
       this.spinner.fail((e as Error).message)

--- a/packages/cli/src/commands/tile/show.ts
+++ b/packages/cli/src/commands/tile/show.ts
@@ -1,18 +1,13 @@
-import { SyncOptions } from '@ceramicnetwork/common/lib/streamopts'
 import { TileDocument } from '@ceramicnetwork/stream-tile'
 
 import { 
   Command, 
-  type CommandFlags,
+  type QueryCommandFlags,
   SYNC_OPTION_FLAG,
   STREAM_ID_ARG
 } from '../../command.js'
 
-type Flags = CommandFlags & {
-  sync?: SyncOptions
-}
-
-export default class ShowTile extends Command<Flags, { streamId: string }> {
+export default class ShowTile extends Command<QueryCommandFlags, { streamId: string }> {
   static description = 'show the contents of a Tile stream'
 
   static args = [

--- a/packages/cli/src/commands/tile/show.ts
+++ b/packages/cli/src/commands/tile/show.ts
@@ -4,22 +4,11 @@ import { TileDocument } from '@ceramicnetwork/stream-tile'
 import { 
   Command, 
   type CommandFlags,
-  SYNC_OPTIONS_MAP,
+  SYNC_OPTION_FLAG
 } from '../../command.js'
 
 type Flags = CommandFlags & {
   syncOption?: SyncOptions
-}
-
-async function parseSyncOption(input: string): Promise<SyncOptions> {
-  return new Promise((resolve, reject) => {
-    const syncOption = SYNC_OPTIONS_MAP[input]
-    if (syncOption) {
-      resolve(syncOption)
-    } else {
-      reject()
-    }
-  })
 }
 
 export default class ShowTile extends Command<Flags, { streamId: string }> {
@@ -31,26 +20,11 @@ export default class ShowTile extends Command<Flags, { streamId: string }> {
       required: true,
       description: 'ID of the stream',
     },
-    {
-      name: 'sync',
-      required: false,
-      options: Object.keys(SYNC_OPTIONS_MAP),
-      description: `
-      Defines if the tile should be retrieved from node's cache, if it's available, always or never.
-      Available choices: 'prefer-cache', 'sync-always', 'sync-never'.
-      'prefer-cache' is the default
-      `
-    },
   ]
 
   static flags = {
     ...Command.flags,
-    syncOption: Flags.integer({
-      char: 's',
-      options: Object.keys(SYNC_OPTIONS_MAP),
-      description: `Controls if the current stream state should be synced over the network or not. 'prefer-cache' will return the state from the node's local cache if present, and will sync from the network if the stream isn't in the cache. 'always-sync' always syncs from the network, even if there is cached state for the stream. 'never-sync' never syncs from the network.`,
-      parse: parseSyncOption
-    }),
+    syncOption: SYNC_OPTION_FLAG,
   }
 
   async run(): Promise<void> {

--- a/packages/cli/src/commands/tile/update.ts
+++ b/packages/cli/src/commands/tile/update.ts
@@ -1,7 +1,11 @@
 import { TileDocument, type TileMetadataArgs } from '@ceramicnetwork/stream-tile'
 import { Flags } from '@oclif/core'
 
-import { Command, type CommandFlags } from '../../command.js'
+import { 
+  Command, 
+  STREAM_ID_ARG, 
+  type CommandFlags,
+} from '../../command.js'
 
 type Flags = CommandFlags & {
   metadata?: TileMetadataArgs
@@ -12,12 +16,9 @@ export default class Update extends Command<Flags, { content: string; streamId: 
   static description = 'Update a stream'
 
   static args = [
-    {
-      name: 'streamId',
-      description: 'ID of the stream',
-      required: true,
-    },
+    STREAM_ID_ARG,
   ]
+  
   static flags = {
     ...Command.flags,
     metadata: Flags.string({

--- a/packages/cli/test/tiles.test.ts
+++ b/packages/cli/test/tiles.test.ts
@@ -36,7 +36,7 @@ describe('tiles', () => {
       const content = await execa('glaze', [
         `tile:content`,
         tile.stderr.toString().split('Created stream ')[1].replace('.', ''),
-        `--syncOption=sync-always`
+        `--sync=sync-always`
       ])
       const lines = stripAnsi(content.stderr.toString())
       expect(lines.includes('Retrieved details of stream')).toBe(true)
@@ -65,11 +65,11 @@ describe('tiles', () => {
         execa('glaze', [
           `tile:content`,
           tile.stderr.toString().split('Created stream ')[1].replace('.', ''),
-          `--syncOption=unsupportedArgument`
+          `--sync=unsupportedArgument`
         ])
       )
       .rejects
-      .toThrow('Expected --syncOption=unsupportedArgument to be one of:')
+      .toThrow('Expected --sync=unsupportedArgument to be one of:')
     }, 60000)
   })
 
@@ -82,7 +82,7 @@ describe('tiles', () => {
       const content = await execa('glaze', [
         `tile:show`,
         tile.stderr.toString().split('Created stream ')[1].replace('.', ''),
-        `--syncOption=never-sync`
+        `--sync=never-sync`
       ])
       const lines = stripAnsi(content.stderr.toString())
       expect(lines.includes('Retrieved details of stream')).toBe(true)
@@ -111,11 +111,11 @@ describe('tiles', () => {
         execa('glaze', [
           `tile:show`,
           tile.stderr.toString().split('Created stream ')[1].replace('.', ''),
-          `--syncOption=unsupportedArgument`
+          `--sync=unsupportedArgument`
         ])
       )
       .rejects
-      .toThrow('Expected --syncOption=unsupportedArgument to be one of:')
+      .toThrow('Expected --sync=unsupportedArgument to be one of:')
     }, 60000)
   })
 
@@ -168,7 +168,7 @@ describe('tiles', () => {
           family: ['test'],
         }),
         `--key=${seed}`,
-        `--syncOption=never-sync`
+        `--sync=never-sync`
       ])
       const stdOut = tile.stderr.toString()
       expect(stdOut.includes('Loaded tile')).toBe(true)
@@ -205,11 +205,11 @@ describe('tiles', () => {
             family: ['test'],
           }),
           `--key=${seed}`,
-          `--syncOption=unsupportedArgument`
+          `--sync=unsupportedArgument`
         ])
       )
       .rejects
-      .toThrow('Expected --syncOption=unsupportedArgument to be one of:')
+      .toThrow('Expected --sync=unsupportedArgument to be one of:')
     }, 60000)
   })
 })

--- a/packages/cli/test/tiles.test.ts
+++ b/packages/cli/test/tiles.test.ts
@@ -42,6 +42,52 @@ describe('tiles', () => {
     }, 60000)
   })
 
+  describe('tile:show', () => {
+    test('displays tile content with syncing option argument', async () => {
+      const key = await execa('glaze', ['did:create'])
+      const seed = stripAnsi(key.stderr.toString().split('with seed ')[1])
+
+      const tile = await execa('glaze', [`tile:create`, `--content={"FOO":"BAR"}`, `--key=${seed}`])
+      const content = await execa('glaze', [
+        `tile:show`,
+        tile.stderr.toString().split('Created stream ')[1].replace('.', ''),
+        `--syncOption=never-sync`
+      ])
+      const lines = stripAnsi(content.stderr.toString())
+      expect(lines.includes('Retrieved details of stream')).toBe(true)
+    }, 60000)
+
+    test('displays tile content without syncing option argument', async () => {
+      const key = await execa('glaze', ['did:create'])
+      const seed = stripAnsi(key.stderr.toString().split('with seed ')[1])
+
+      const tile = await execa('glaze', [`tile:create`, `--content={"FOO":"BAR"}`, `--key=${seed}`])
+      const content = await execa('glaze', [
+        `tile:show`,
+        tile.stderr.toString().split('Created stream ')[1].replace('.', ''),
+      ])
+      const lines = stripAnsi(content.stderr.toString())
+      expect(lines.includes('Retrieved details of stream')).toBe(true)
+      expect(lines.includes('Syncing option chosen')).toBe(false)
+    }, 60000)
+
+    test('fails when unsupported syncing option is passed', async () => {
+      const key = await execa('glaze', ['did:create'])
+      const seed = stripAnsi(key.stderr.toString().split('with seed ')[1])
+
+      const tile = await execa('glaze', [`tile:create`, `--content={"FOO":"BAR"}`, `--key=${seed}`])
+      await expect(
+        execa('glaze', [
+          `tile:show`,
+          tile.stderr.toString().split('Created stream ')[1].replace('.', ''),
+          `--syncOption=unsupportedArgument`
+        ])
+      )
+      .rejects
+      .toThrow('Expected --syncOption=unsupportedArgument to be one of:')
+    }, 60000)
+  })
+
   describe('tile:update', () => {
     test('successfully updates tile', async () => {
       const key = await execa('glaze', ['did:create'])

--- a/packages/cli/test/tiles.test.ts
+++ b/packages/cli/test/tiles.test.ts
@@ -28,7 +28,21 @@ describe('tiles', () => {
   })
 
   describe('tile:content', () => {
-    test('displays tile content', async () => {
+    test('displays tile content with syncing option argument', async () => {
+      const key = await execa('glaze', ['did:create'])
+      const seed = stripAnsi(key.stderr.toString().split('with seed ')[1])
+
+      const tile = await execa('glaze', [`tile:create`, `--content={"FOO":"BAR"}`, `--key=${seed}`])
+      const content = await execa('glaze', [
+        `tile:content`,
+        tile.stderr.toString().split('Created stream ')[1].replace('.', ''),
+        `--syncOption=sync-always`
+      ])
+      const lines = stripAnsi(content.stderr.toString())
+      expect(lines.includes('Retrieved details of stream')).toBe(true)
+    }, 60000)
+
+    test('displays tile content without syncing option argument', async () => {
       const key = await execa('glaze', ['did:create'])
       const seed = stripAnsi(key.stderr.toString().split('with seed ')[1])
 
@@ -39,6 +53,23 @@ describe('tiles', () => {
       ])
       const lines = stripAnsi(content.stderr.toString())
       expect(lines.includes('Retrieved details of stream')).toBe(true)
+      expect(lines.includes('Syncing option chosen')).toBe(false)
+    }, 60000)
+
+    test('fails when unsupported syncing option is passed', async () => {
+      const key = await execa('glaze', ['did:create'])
+      const seed = stripAnsi(key.stderr.toString().split('with seed ')[1])
+
+      const tile = await execa('glaze', [`tile:create`, `--content={"FOO":"BAR"}`, `--key=${seed}`])
+      await expect(
+        execa('glaze', [
+          `tile:content`,
+          tile.stderr.toString().split('Created stream ')[1].replace('.', ''),
+          `--syncOption=unsupportedArgument`
+        ])
+      )
+      .rejects
+      .toThrow('Expected --syncOption=unsupportedArgument to be one of:')
     }, 60000)
   })
 


### PR DESCRIPTION
Add sync options to the glaze CLI

## Description

When loading a stream from Ceramic there are different SyncOptions that can be set: https://github.com/ceramicnetwork/js-ceramic/blob/86bcf3cdf19faa0507e38de6fe8f29004aa8fd5b/packages/common/src/streamopts.ts#L16-L33

It would be good for the glaze CLI to expose this.  In particular, some users want to be able to check that their node's persistence setup works, but it's difficult to reliably tell currently if when you load a stream via your node if your node is getting it from its local state store or by syncing it from another node on the network (like the CAS, which pins all streams by default).  Having a NEVER_SYNC option would make it easy for a node operator to check if a Stream's state is stored locally on their own node.

## How Has This Been Tested?

Describe the tests that you ran to verify your changes. Provide instructions for reproduction.

- [x] Implemented tests for all affected commands in `tiles.tests.ts`
- [x] I added logging of options in my local ceramic cli and was running local glaze commands agains it:

   * `* node bin/run.js did:create`
      ```
      ✔ Created DID did:key:z6MkhEcwdqFqwiT7r7fXB3FWfkFgwh5qz2gKopWp5asLK25f with seed 
      b8d88dfac40ae3e327ade2da2b197796e13c85fc93f41fc68c74d3479db60e93
      ```

   * `node bin/run.js tile:create --key b8d88dfac40ae3e327ade2da2b197796e13c85fc93f41fc68c74d3479db60e93 --content '{"Foo":"Baz"}' `
      ```
      ℹ Using DID did:key:z6MkhEcwdqFqwiT7r7fXB3FWfkFgwh5qz2gKopWp5asLK25f
          ✔ Created stream kjzl6cwe1jw14aw4cb6k0mh42tu6dte66tese9m4pnus3jgbx69qv81p1nosonj.
          {
            streamID: 'kjzl6cwe1jw14aw4cb6k0mh42tu6dte66tese9m4pnus3jgbx69qv81p1nosonj',
            content: { Foo: 'Baz' }
          }
      ```

   * `node bin/run.js stream:state kjzl6cwe1jw14aw4cb6k0mh42tu6dte66tese9m4pnus3jgbx69qv81p1nosonj -s never-sync`
      ```
       ✔ Successfully queried stream kjzl6cwe1jw14aw4cb6k0mh42tu6dte66tese9m4pnus3jgbx69qv81p1nosonj.
       (...)
      ```
      Logs from ceramic daemon:
      ```
      Getting state with options { sync: 2 }
      Loading with options { sync: 2 }
      ```
   * `node bin/run.js stream:commits kjzl6cwe1jw14aw4cb6k0mh42tu6dte66tese9m4pnus3jgbx69qv81p1nosonj --sync never-sync`
      ```
      ✔ Stream commits loaded.
      [ 'k3y52l7qbv1frylgevjimcftp046le90s0h55xgddihmvt6c4rwlb21823sgbzbb4' ]
      ```
      Logs from ceramic daemon:
      ```
      Getting state with options { sync: 2 }
      Loading with options { sync: 2 }
      ```
  
   * `node bin/run.js tile:show kjzl6cwe1jw14aw4cb6k0mh42tu6dte66tese9m4pnus3jgbx69qv81p1nosonj -s never-sync`
        ```
        ✔ Retrieved details of stream kjzl6cwe1jw14aw4cb6k0mh42tu6dte66tese9m4pnus3jgbx69qv81p1nosonj.
        { Foo: 'Baz' }
        ```
        Logs from ceramic daemon:
        ```
        Getting state with options { sync: 2 }
        Loading with options { sync: 2 }
        ```
    * `node bin/run.js tile:content kjzl6cwe1jw14aw4cb6k0mh42tu6dte66tese9m4pnus3jgbx69qv81p1nosonj --sync never-sync`
       ```
        ✔ Retrieved details of stream kjzl6cwe1jw14aw4cb6k0mh42tu6dte66tese9m4pnus3jgbx69qv81p1nosonj.
        { Foo: 'Baz' }
        ```
        Logs from ceramic daemon:
        ```
        Getting state with options { sync: 2 }
        Loading with options { sync: 2 }
        ```
  *  `node bin/run.js tile:deterministic '{"controllers":["did:key:z6MkhEcwdqFqwiT7r7fXB3FWfkFgwh5qz2gKopWp5asLK25f"],"tags":["foo","bar"],"family":["test"]}'  --key 1472ce8293ddde83b4a7cd7182285c2f85b5ca11f54f8a9703636bb247b8031f -s never-sync`
      ```
      ℹ Using DID did:key:z6MkrRdSnM3tDak5Rnuwx1TTYCnVHJXJfwNNXzAhoHrxMxZc
      ✔ 
              Loaded tile k2t6wyfsu4pg2vx6mc38jvblfeehn06k40wpqky9it4ukpjh1zyd12jdcv88hn.
      {
        streamID: 'k2t6wyfsu4pg2vx6mc38jvblfeehn06k40wpqky9it4ukpjh1zyd12jdcv88hn',
        content: {}
      }
      ```
      Logs from ceramic daemon:
      ```
      Create stream from genesis with options { anchor: true, publish: true, sync: 2, pin: true }
      ```

## Definition of Done

Before submitting this PR, please make sure:

- [x] The work addresses the description and outcomes in the issue
- [x] I have added relevant tests for new or updated functionality
- [x] My code follows conventions, is well commented, and easy to understand
- [ ] My code builds and tests pass without any errors or warnings
- [ ] I have tagged the relevant reviewers
- [x] I have updated the READMEs of affected packages
- [ ] I have made corresponding changes to the documentation
- [x] The changes have been communicated to interested parties

## References:

Please list relevant documentation (e.g. tech specs, articles, related work etc.) relevant to this change, and note if the documentation has been updated.
