### PR TITLE
feat(did-datastore): support session/cacao parent

### DIFF
--- a/packages/did-datastore/src/index.ts
+++ b/packages/did-datastore/src/index.ts
@@ -295,7 +295,7 @@ export class DIDDataStore<
     if (this.#ceramic.did == null) {
       throw new Error('Ceramic instance is not authenticated')
     }
-    return this.#ceramic.did.id
+    return this.#ceramic.did.hasParent ? this.#ceramic.did.parent : this.#ceramic.did.id
   }
 
   /**


### PR DESCRIPTION
Adds support for did-session in did-datastore by using parent (cap issuer) 