### PR TITLE
Fix/correctly parse required graphql lists apps 582

### DIFF
--- a/packages/devtools/src/schema.ts
+++ b/packages/devtools/src/schema.ts
@@ -264,14 +264,38 @@ function fieldSchemaFromFieldDefinition(
   ceramicExtensions?: CeramicGraphQLTypeExtensions
 ): JSONSchema {
   if (fieldType instanceof GraphQLObjectType) {
-    return referenceFieldSchemaFromFieldDefinition(fieldType) || {}
+    const objectSchema = referenceFieldSchemaFromFieldDefinition(fieldType)
+    if (!objectSchema) {
+      throw new Error('Unexpected error when parsing an object definition')
+    }
+    return objectSchema
   }
   if (fieldType instanceof GraphQLNonNull && fieldType.ofType instanceof GraphQLObjectType) {
-    return referenceFieldSchemaFromFieldDefinition(fieldType.ofType) || {}
+    const objectSchema = referenceFieldSchemaFromFieldDefinition(fieldType.ofType)
+    if (!objectSchema) {
+      throw new Error('Unexpected error when parsing an object definition')
+    }
+    return objectSchema
   }
   if (fieldType instanceof GraphQLList) {
-    return arrayFieldSchemaFromFieldDefinition(fieldName, fieldType, ceramicExtensions) || {}
+    const arraySchema = arrayFieldSchemaFromFieldDefinition(fieldName, fieldType, ceramicExtensions)
+    if (!arraySchema) {
+      throw new Error('Unexpected error when parsing a list definition')
+    }
+    return arraySchema
   }
+  if (fieldType instanceof GraphQLNonNull && fieldType.ofType instanceof GraphQLList) {
+    const arraySchema = arrayFieldSchemaFromFieldDefinition(
+      fieldName,
+      fieldType.ofType,
+      ceramicExtensions
+    )
+    if (!arraySchema) {
+      throw new Error('Unexpected error when parsing a list definition')
+    }
+    return arraySchema
+  }
+
   return defaultFieldSchemaFromFieldDefinition(fieldType, ceramicExtensions)
 }
 

--- a/packages/devtools/test/schema.test.ts
+++ b/packages/devtools/test/schema.test.ts
@@ -324,6 +324,47 @@ describe('schema', () => {
     })
   })
 
+  it('Arrays are supported and properly converted to ICD', () => {
+    expect(
+      compositeModelsAndCommonEmbedsFromGraphQLSchema(`
+      type ModelWithArrayProp @model(
+        accountRelation: LINK,
+        description: "Test model with GraphQL ID property"
+      ) {
+        arrayValue: [Int]
+        requiredArrayValue: [Int]!
+      }
+      `)
+    ).toMatchObject({
+      models: [
+        {
+          name: 'ModelWithArrayProp',
+          accountRelation: 'link',
+          schema: {
+            $schema: 'https://json-schema.org/draft/2020-12/schema',
+            type: 'object',
+            properties: {
+              arrayValue: {
+                type: 'array',
+                items: {
+                  type: 'integer',
+                },
+              },
+              requiredArrayValue: {
+                type: 'array',
+                items: {
+                  type: 'integer',
+                },
+              },
+            },
+            additionalProperties: false,
+            required: ['requiredArrayValue'],
+          },
+        },
+      ],
+    })
+  })
+
   it('@length(min: Int, max: Int) directive is supported for strings and properly converted to ICD', () => {
     expect(
       compositeModelsAndCommonEmbedsFromGraphQLSchema(`


### PR DESCRIPTION
# GraphQL SDL Composite Definitions using required array properties are not parsed properly.

## Description

This PR fixes the bug described below.

Steps to reproduce the bug:

1. In your home dir create a file called composite.schema with the following contents:
```
type ModelWithRequiredArraypro @model(
  accountRelation: LINK,
  description: "A model with required array pro"
) {
  requiredArrayPro: [String]!
}
```

2. Use glaze cli and run  `node bin/run.js composite:create ~/composite.schema -k <your-did-seed> -o ~/encoded.composite.json`

Notice that the output you'll get is:

✖ HTTP request to 'http://localhost:7007/api/v0/streams' failed with status 'Internal Server Error': {"error":"Validation Error: data/properties/requiredArrayPro/type must be equal to one of the allowed values, data/properties/requiredArrayPro/type must be array, data/properties/requiredArrayPro/type must match a schema in anyOf"}

Expected behavior:
The encoded composite definition should be correctly created

Additional context
This happens because the input model's GraphQL SDL definition is translated to the following JSON Schema definition:
```
{
    "$schema": "https://json-schema.org/draft/2020-12/schema",
    "type": "object",
    "additionalProperties": false,
    "properties": {
        "requiredArrayPro": {
            "type": "[string]!"
        }
    },
    "required": [
        "requiredArrayPro"
    ]
}
```
while it should be translated to this:
```
{
    "$schema": "https://json-schema.org/draft/2020-12/schema",
    "type": "object",
    "additionalProperties": false,
    "properties": {
        "requiredArrayPro": {
            "type": "array",
            "items": {
                "type": "string"
            }
        }
    },
    "required": ["requiredArrayPro"]
}
```
## How Has This Been Tested?

Describe the tests that you ran to verify your changes. Provide instructions for reproduction.

- [X] Added a test for schema parsing that checks this case

## Definition of Done

Before submitting this PR, please make sure:

- [X] The work addresses the description and outcomes in the issue
- [X] I have added relevant tests for new or updated functionality
- [X] My code follows conventions, is well commented, and easy to understand
- [X] My code builds and tests pass without any errors or warnings
- [X] I have tagged the relevant reviewers

