### PR TITLE
Feat/new glaze commands for models apps 572

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,3 +1,4 @@
+
 # Glaze CLI
 
 ## [Documentation](https://developers.ceramic.network/tools/glaze/development/#cli)
@@ -28,14 +29,9 @@ glaze COMMAND
 - [`glaze did:sign CONTENTS`](#glaze-didsign-contents)
 - [`glaze did:verify JWS`](#glaze-didverify-jws)
 - [`glaze help [COMMAND]`](#glaze-help-command)
-- [`glaze model:add NAME TYPE ALIAS STREAM`](#glaze-modeladd-name-type-alias-stream)
-- [`glaze model:create NAME`](#glaze-modelcreate-name)
-- [`glaze model:delete NAME`](#glaze-modeldelete-name)
-- [`glaze model:deploy NAME [OUTPUT]`](#glaze-modeldeploy-name-output)
-- [`glaze model:export NAME [OUTPUT]`](#glaze-modelexport-name-output)
-- [`glaze model:import LOCALNAME IMPORTNAME`](#glaze-modelimport-localname-importname)
-- [`glaze model:inspect NAME`](#glaze-modelinspect-name)
-- [`glaze model:list`](#glaze-modellist)
+- [`glaze model:create CONTENT`](#glaze-modelcreate-content)
+- [`glaze model:content STREAMID`](#glaze-modelcontent-streamid)
+- [`glaze model:controller STREAMID`](#glaze-modelcontroller-streamid)
 - [`glaze composite:create INPUT [OUTPUT]`](#glaze-compositecreate)
 - [`glaze pin:add STREAMID`](#glaze-pinadd-streamid)
 - [`glaze pin:ls [STREAMID]`](#glaze-pinls-streamid)
@@ -242,97 +238,47 @@ OPTIONS
   --schema=schema        tile schema
 ```
 
-### `glaze model:create NAME`
+### `glaze model:create CONTENT`
 
-create a local model
-
-```
-USAGE
-  $ glaze model:create NAME
-
-OPTIONS
-  -c, --ceramic=ceramic  Ceramic API URL
-```
-
-### `glaze model:delete NAME`
-
-delete a local model
+create a model stream with given content
 
 ```
 USAGE
-  $ glaze model:delete NAME
-
-OPTIONS
-  -c, --ceramic=ceramic  Ceramic API URL
-  -f, --force            bypass confirmation prompt
-```
-
-### `glaze model:deploy NAME [OUTPUT]`
-
-deploy a model
-
-```
-USAGE
-  $ glaze model:deploy NAME [OUTPUT]
+  $ glaze model:create CONTENT
 
 ARGUMENTS
-  NAME    local model name or package
-  OUTPUT  JSON file to output the deployed model aliases
+  CONTENT contents of the model encoded as JSON
 
 OPTIONS
   -c, --ceramic=ceramic  Ceramic API URL
 ```
 
-### `glaze model:export NAME [OUTPUT]`
+### `glaze model:content STREAMID`
 
-export a model
+load the contents of a model stream with a given ID
 
 ```
 USAGE
-  $ glaze model:export NAME [OUTPUT]
+  $ glaze model:content STREAMID
 
 ARGUMENTS
-  NAME    local model name or package
-  OUTPUT  JSON file to output the model to
+  STREAMID ID of the stream
 
 OPTIONS
   -c, --ceramic=ceramic  Ceramic API URL
+  -o, --output           Path to a file where the content should be saved
 ```
 
-### `glaze model:import LOCALNAME IMPORTNAME`
+### `glaze model:controller STREAMID`
 
-import a model into another one
-
-```
-USAGE
-  $ glaze model:import LOCALNAME IMPORTNAME
-
-OPTIONS
-  -c, --ceramic=ceramic  Ceramic API URL
-```
-
-### `glaze model:inspect NAME`
-
-inspect a model
+load the model stream with a given ID and display its controller DID
 
 ```
 USAGE
-  $ glaze model:inspect NAME
+  $ glaze model:controller STREAMID
 
 ARGUMENTS
-  NAME  local model name or package
-
-OPTIONS
-  -c, --ceramic=ceramic  Ceramic API URL
-```
-
-### `glaze model:list`
-
-list local models
-
-```
-USAGE
-  $ glaze model:list
+  STREAMID ID of the stream
 
 OPTIONS
   -c, --ceramic=ceramic  Ceramic API URL

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -76,6 +76,7 @@
     "@ceramicnetwork/3id-did-resolver": "^2.1.2",
     "@ceramicnetwork/http-client": "^2.2.1",
     "@ceramicnetwork/stream-tile": "^2.2.2",
+    "@ceramicnetwork/stream-model": "^0.2.1",
     "@ceramicnetwork/streamid": "^2.1.0",
     "@glazed/datamodel": "^0.3.0",
     "@glazed/devtools": "^0.2.0",

--- a/packages/cli/src/commands/model/content.ts
+++ b/packages/cli/src/commands/model/content.ts
@@ -1,0 +1,46 @@
+import { Model } from '@ceramicnetwork/stream-model'
+import { Command, type QueryCommandFlags, STREAM_ID_ARG, SYNC_OPTION_FLAG } from '../../command.js'
+import { Flags } from '@oclif/core'
+import fs from 'fs-extra'
+
+type ModelContentFlags = QueryCommandFlags & {
+  output?: string
+}
+
+export default class ModelContent extends Command<ModelContentFlags, { streamId: string }> {
+  static description =
+    'load a model stream with a given stream id and display its contents'
+
+  static args = [STREAM_ID_ARG]
+
+  static flags = {
+    ...Command.flags,
+    output: Flags.string({
+      char: 'o',
+      description: 'path to the file where the composite representation should be saved',
+    }),
+
+    sync: SYNC_OPTION_FLAG,
+  }
+
+  async run(): Promise<void> {
+    this.spinner.start('Loading the model...')
+    try {
+      const model = await Model.load(this.ceramic, this.args.streamId)
+      const modelContentAsJSON = JSON.stringify(model.content, null, 2)
+      if (this.flags.output !== undefined) {
+        const output = this.flags.output
+        await fs.writeFile(output, modelContentAsJSON)
+        this.spinner.succeed(
+          `Model's content was loaded and saved in ${output}`
+        )
+      } else {
+        this.spinner.succeed(modelContentAsJSON)
+      }
+    } catch (e) {
+      this.spinner.fail((e as Error).message)
+      return
+    }
+    
+  }
+}

--- a/packages/cli/src/commands/model/content.ts
+++ b/packages/cli/src/commands/model/content.ts
@@ -8,8 +8,7 @@ type ModelContentFlags = QueryCommandFlags & {
 }
 
 export default class ModelContent extends Command<ModelContentFlags, { streamId: string }> {
-  static description =
-    'load a model stream with a given stream id and display its contents'
+  static description = 'load a model stream with a given stream id and display its contents'
 
   static args = [STREAM_ID_ARG]
 
@@ -31,9 +30,7 @@ export default class ModelContent extends Command<ModelContentFlags, { streamId:
       if (this.flags.output !== undefined) {
         const output = this.flags.output
         await fs.writeFile(output, modelContentAsJSON)
-        this.spinner.succeed(
-          `Model's content was loaded and saved in ${output}`
-        )
+        this.spinner.succeed(`Model's content was loaded and saved in ${output}`)
       } else {
         this.spinner.succeed(modelContentAsJSON)
       }

--- a/packages/cli/src/commands/model/controller.ts
+++ b/packages/cli/src/commands/model/controller.ts
@@ -1,0 +1,26 @@
+import { Model } from '@ceramicnetwork/stream-model'
+import { Command, type QueryCommandFlags, STREAM_ID_ARG, SYNC_OPTION_FLAG } from '../../command.js'
+
+export default class ModelController extends Command<QueryCommandFlags, { streamId: string }> {
+  static description = 'load a model stream with a given stream id and display its controller'
+
+  static args = [STREAM_ID_ARG]
+
+  static flags = {
+    ...Command.flags,
+    sync: SYNC_OPTION_FLAG,
+  }
+
+  async run(): Promise<void> {
+    this.spinner.start('Loading the model...')
+    try {
+      const model = await Model.load(this.ceramic, this.args.streamId)
+      this.spinner.succeed(
+        `Model's content was loaded. It's controller is ${model.metadata.controllers[0].toString()}`
+      )
+    } catch (e) {
+      this.spinner.fail((e as Error).message)
+      return
+    }
+  }
+}

--- a/packages/cli/src/commands/model/create.ts
+++ b/packages/cli/src/commands/model/create.ts
@@ -1,0 +1,35 @@
+import { Model, ModelDefinition } from '@ceramicnetwork/stream-model'
+import { Command, type CommandFlags } from '../../command.js'
+
+/*
+model:create '{"name":"MyModel","accountRelation":"list","schema":{"$schema":"https://json-schema.org/draft/2020-12/schema","type":"object","properties":{"stringPropName":{"type":"string","maxLength":80}},"additionalProperties":false,"required":["stringPropName"]}}' -k <did_seed>
+ */
+
+export default class CreateModel extends Command<CommandFlags, { content: string }> {
+  static description = 'create a model stream from content encoded as JSON'
+
+  static args = [
+    {
+      name: 'content',
+      required: true,
+      description: 'Model content (JSON encoded as string)',
+    },
+  ]
+
+  async run(): Promise<void> {
+    this.spinner.start('Creating the model...')
+    try {
+      const model = await Model.create(
+        this.ceramic,
+        JSON.parse(this.args.content) as ModelDefinition,
+        {
+          controller: this.authenticatedDID.id,
+        }
+      )
+      this.spinner.succeed(`Created ${model.content.name} with streamID ${model.id.toString()}`)
+    } catch (e) {
+      this.spinner.fail((e as Error).message)
+      return
+    }
+  }
+}

--- a/packages/cli/src/commands/model/create.ts
+++ b/packages/cli/src/commands/model/create.ts
@@ -1,10 +1,6 @@
 import { Model, ModelDefinition } from '@ceramicnetwork/stream-model'
 import { Command, type CommandFlags } from '../../command.js'
 
-/*
-model:create '{"name":"MyModel","accountRelation":"list","schema":{"$schema":"https://json-schema.org/draft/2020-12/schema","type":"object","properties":{"stringPropName":{"type":"string","maxLength":80}},"additionalProperties":false,"required":["stringPropName"]}}' -k <did_seed>
- */
-
 export default class CreateModel extends Command<CommandFlags, { content: string }> {
   static description = 'create a model stream from content encoded as JSON'
 

--- a/packages/cli/test/models.test.ts
+++ b/packages/cli/test/models.test.ts
@@ -26,11 +26,7 @@ describe('models', () => {
       const key = await execa('glaze', ['did:create'])
       const seed = stripAnsi(key.stderr.toString().split('with seed ')[1])
 
-      const create = await execa('glaze', [
-        'model:create',
-        MY_MODEL_JSON,
-        `--key=${seed}`,
-      ])
+      const create = await execa('glaze', ['model:create', MY_MODEL_JSON, `--key=${seed}`])
       expect(create.stderr.toString().includes('Created MyModel with streamID')).toBe(true)
     }, 60000)
   })
@@ -46,11 +42,7 @@ describe('models', () => {
       const key = await execa('glaze', ['did:create'])
       const seed = stripAnsi(key.stderr.toString().split('with seed ')[1])
 
-      const create = await execa('glaze', [
-        'model:create',
-        MY_MODEL_JSON,
-        `--key=${seed}`,
-      ])
+      const create = await execa('glaze', ['model:create', MY_MODEL_JSON, `--key=${seed}`])
 
       const content = await execa('glaze', [
         `model:content`,
@@ -66,6 +58,32 @@ describe('models', () => {
       expect(lines.includes('"$schema": "https://json-schema.org/draft/2020-12/schema",')).toBe(
         true
       )
+    }, 60000)
+  })
+
+  describe('model:controller', () => {
+    test('model controller display fails without the streamID', async () => {
+      await expect(execa('glaze', ['model:controller'])).rejects.toThrow(
+        /streamId {2}ID of the stream/
+      )
+    }, 60000)
+
+    test('model controller display succeeds', async () => {
+      const key = await execa('glaze', ['did:create'])
+      const did = stripAnsi(key.stderr.toString().split('with seed ')[0])
+        .split('Created DID ')[1]
+        .replace(' ', '')
+      const seed = stripAnsi(key.stderr.toString().split('with seed ')[1])
+
+      const create = await execa('glaze', ['model:create', MY_MODEL_JSON, `--key=${seed}`])
+
+      const controller = await execa('glaze', [
+        `model:controller`,
+        create.stderr.toString().split('with streamID ')[1].replace('.', ''),
+        `--sync=sync-always`,
+      ])
+
+      expect(controller.stderr.toString().split("It's controller is ")[1]).toEqual(did)
     }, 60000)
   })
 })

--- a/packages/cli/test/models.test.ts
+++ b/packages/cli/test/models.test.ts
@@ -31,9 +31,41 @@ describe('models', () => {
         MY_MODEL_JSON,
         `--key=${seed}`,
       ])
-      console.log(create.stderr.toString())
-
       expect(create.stderr.toString().includes('Created MyModel with streamID')).toBe(true)
+    }, 60000)
+  })
+
+  describe('model:content', () => {
+    test('model content display fails without the streamID', async () => {
+      await expect(execa('glaze', ['model:content'])).rejects.toThrow(
+        /streamId {2}ID of the stream/
+      )
+    }, 60000)
+
+    test('model content display succeeds', async () => {
+      const key = await execa('glaze', ['did:create'])
+      const seed = stripAnsi(key.stderr.toString().split('with seed ')[1])
+
+      const create = await execa('glaze', [
+        'model:create',
+        MY_MODEL_JSON,
+        `--key=${seed}`,
+      ])
+
+      const content = await execa('glaze', [
+        `model:content`,
+        create.stderr.toString().split('with streamID ')[1].replace('.', ''),
+        `--sync=sync-always`,
+      ])
+      const lines = stripAnsi(content.stderr.toString())
+      expect(lines.includes('"name": "MyModel"')).toBe(true)
+      expect(lines.includes('"schema": {')).toBe(true)
+      expect(lines.includes('"type": "object",')).toBe(true)
+      expect(lines.includes('"properties": {')).toBe(true)
+      expect(lines.includes('"accountRelation": "list"')).toBe(true)
+      expect(lines.includes('"$schema": "https://json-schema.org/draft/2020-12/schema",')).toBe(
+        true
+      )
     }, 60000)
   })
 })

--- a/packages/cli/test/models.test.ts
+++ b/packages/cli/test/models.test.ts
@@ -1,0 +1,39 @@
+import { execa } from 'execa'
+import stripAnsi from 'strip-ansi'
+
+const MY_MODEL_JSON =
+  '{"name":"MyModel","accountRelation":"list","schema":{"$schema":"https://json-schema.org/draft/2020-12/schema","type":"object","properties":{"stringPropName":{"type":"string","maxLength":80}},"additionalProperties":false,"required":["stringPropName"]}}'
+
+describe('models', () => {
+  describe('model:create', () => {
+    test('model creation fails without the content param', async () => {
+      await expect(execa('glaze', ['model:create'])).rejects.toThrow(
+        /Model content \(JSON encoded as string\)/
+      )
+    }, 60000)
+
+    test('model creation fails without the did-key param', async () => {
+      const create = await execa('glaze', ['model:create', MY_MODEL_JSON])
+      const lines = create.stderr.toString().split('\n')
+      expect(
+        lines[1].includes(
+          'DID is not authenticated, make sure to provide a seed using the "did-key"'
+        )
+      ).toBe(true)
+    }, 60000)
+
+    test('model creation succeeds', async () => {
+      const key = await execa('glaze', ['did:create'])
+      const seed = stripAnsi(key.stderr.toString().split('with seed ')[1])
+
+      const create = await execa('glaze', [
+        'model:create',
+        MY_MODEL_JSON,
+        `--key=${seed}`,
+      ])
+      console.log(create.stderr.toString())
+
+      expect(create.stderr.toString().includes('Created MyModel with streamID')).toBe(true)
+    }, 60000)
+  })
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -4131,6 +4131,11 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-15.14.9.tgz#bc43c990c3c9be7281868bbc7b8fdd6e2b57adfa"
   integrity sha512-qjd88DrCxupx/kJD5yQgZdcYKZKSIGBVDIBE1/LTGcNm3d2Np/jxojkdePDdfnBHJc5W7vSMpbJ1aB7p/Py69A==
 
+"@types/node@^17.0.42":
+  version "17.0.45"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.45.tgz#2c0fafd78705e7a18b7906b5201a522719dc5190"
+  integrity sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==
+
 "@types/normalize-package-data@^2.4.0":
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz#d3357479a0fdfdd5907fe67e17e0a85c906e1301"


### PR DESCRIPTION
New commands for models in glaze cli - #[Issue]

## Description

Implemented the following new `models:*` commands which are used to interact with the new `Model` stream from `ceramic`:
* `model:create`
* `model:content`
* `model:controller`

## How Has This Been Tested?

- [X] Added integration tests for all new commands
- [X] Tested the new commands manually against a locally running `ceramic` daemon:
```
☁  cli [feat/new-glaze-commands-for-models-APPS-572] ⚡ node bin/run.js did:create             
✔ Created DID did:key:z6Mkua2VaRUTMYDrQwTt24hrpxU25EaiU29LokfTsnHn9sxd with seed d9a594fd8ff4beb806e868f8b23bc48b68d7d3293b75a7368e6c9751434c3b89

☁  cli [feat/new-glaze-commands-for-models-APPS-572] ⚡ node bin/run.js model:create '{"name":"MyModel","accountRelation":"list","schema":{"$schema":"https://json-schema.org/draft/2020-12/schema","type":"object","properties":{"stringPropName":{"type":"string","maxLength":80}},"additionalProperties":false,"required":["stringPropName"]}}' -k 7e4ac0e3d7c785e6d1be4e836cdaf956ad65949f2a4dabaa1fc67eac751058fa
ℹ Using DID did:key:z6MkjatbMPPTirQBtqjGEo267MTMuQcerKY6zTx4fy3BEPKM
✔ Created MyModel with streamID kjzl6hvfrbw6c5sg7zjlscg00voeg50clf19zfma33en7swapz8g1j0fy2499cz

☁  cli [feat/new-glaze-commands-for-models-APPS-572] ⚡ node bin/run.js model:content kjzl6hvfrbw6c5sg7zjlscg00voeg50clf19zfma33en7swapz8g1j0fy2499cz
✔ {
  "name": "MyModel",
  "schema": {
    "type": "object",
    "$schema": "https://json-schema.org/draft/2020-12/schema",
    "required": [
      "stringPropName"
    ],
    "properties": {
      "stringPropName": {
        "type": "string",
        "maxLength": 80
      }
    },
    "additionalProperties": false
  },
  "accountRelation": "list"
}

☁  cli [feat/new-glaze-commands-for-models-APPS-572] ⚡ node bin/run.js model:content kjzl6hvfrbw6c5sg7zjlscg00voeg50clf19zfma33en7swapz8g1j0fy2499cz -o ~/mymodel.content.json
✔ Model's content was loaded and saved in /Users/arturwdowiarski/mymodel.content.json

☁  cli [feat/new-glaze-commands-for-models-APPS-572] ⚡ node bin/run.js model:controller kjzl6hvfrbw6c5sg7zjlscg00voeg50clf19zfma33en7swapz8g1j0fy2499cz
✔ Model's content was loaded. It's controller is did:key:z6MkjatbMPPTirQBtqjGEo267MTMuQcerKY6zTx4fy3BEPKM
```

## Definition of Done

Before submitting this PR, please make sure:

- [x] The work addresses the description and outcomes in the issue
- [x] I have added relevant tests for new or updated functionality
- [x] My code follows conventions, is well commented, and easy to understand
- [x] My code builds and tests pass without any errors or warnings
- [x] I have tagged the relevant reviewers
- [x] I have updated the READMEs of affected packages
- [ ] I have made corresponding changes to the documentation
- [x] The changes have been communicated to interested parties

## References:

Please list relevant documentation (e.g. tech specs, articles, related work etc.) relevant to this change, and note if the documentation has been updated.
